### PR TITLE
SearchComplete should return empty array instead of null

### DIFF
--- a/pkg/resolver/searchComplete.go
+++ b/pkg/resolver/searchComplete.go
@@ -93,7 +93,7 @@ func (s *SearchCompleteResult) searchCompleteResults(ctx context.Context) ([]*st
 		klog.Error("Error fetching search complete results from db ", err)
 	}
 	defer rows.Close()
-	var srchCompleteOut []*string
+	srchCompleteOut := make([]*string, 0)
 	if rows != nil {
 		for rows.Next() {
 			prop := ""


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

### Changes
Fixes problem where Search UI goes blank when SearchComplete returns no values. The API should return an empty array instead of null.

Verified deleting the postgres pod.
<img width="983" alt="image" src="https://user-images.githubusercontent.com/4671325/167009586-92c7bbbe-a7d5-43f9-858c-68ce48af157c.png">
