### PR TITLE
Remove local-hub from managedCluster cache

### DIFF
--- a/pkg/rbac/authzMiddleware.go
+++ b/pkg/rbac/authzMiddleware.go
@@ -20,17 +20,14 @@ func AuthorizeUser(next http.Handler) http.Handler {
 			klog.Warning("Unexpected error while obtaining cluster-scoped resources.", err)
 			metric.AuthzFailed.WithLabelValues("UnexpectedAuthzError").Inc()
 		}
-		klog.Info("Finished getting shared resources. Now getting user data..")
+		klog.V(6).Info("Finished getting shared resources. Now getting user data..")
 
 		_, userErr := CacheInst.GetUserData(r.Context(), nil)
 		if userErr != nil {
 			klog.Warning("Unexpected error while obtaining user data.", userErr)
 		}
 
-		//Managed Cluster resources authorization:
-		// userData.getManagedClusterResources()
-
-		klog.V(5).Info("User authorization successful!")
+		klog.V(6).Info("User authorization successful!")
 		next.ServeHTTP(w, r.WithContext(r.Context()))
 
 	})

--- a/pkg/rbac/sharedData.go
+++ b/pkg/rbac/sharedData.go
@@ -198,8 +198,9 @@ func (shared *SharedData) GetManagedClusters(cache *Cache, ctx context.Context) 
 	}
 
 	for _, item := range resourceObj.Items {
-		managedClusters = append(managedClusters, item.GetName())
-
+		if item.GetName() != "local-cluster" {
+			managedClusters = append(managedClusters, item.GetName())
+		}
 	}
 
 	shared.managedClusters = managedClusters


### PR DESCRIPTION
Signed-off-by: Anxhela <acoba@redhat.com>

**Related Issue:**  stolostron/backlog#22013

### Description of changes
ManagedCluster cache in sharedData should not contain local-cluster.