### PR TITLE
Avoid leaking properties in loop

### DIFF
--- a/pkg/resolver/search.go
+++ b/pkg/resolver/search.go
@@ -259,12 +259,12 @@ func (s *SearchResult) resolveItems() ([]map[string]interface{}, error) {
 	}
 	defer rows.Close()
 
-	var cluster string
-	var data map[string]interface{}
 	s.uids = make([]*string, len(items))
 
 	for rows.Next() {
 		var uid string
+		var cluster string
+		var data map[string]interface{}
 		err = rows.Scan(&uid, &cluster, &data)
 		if err != nil {
 			klog.Errorf("Error %s retrieving rows for query:%s", err.Error(), s.query)


### PR DESCRIPTION
Signed-off-by: Sherin Varughese <shvarugh@redhat.com>

**Related Issue:**  https://github.com/stolostron/backlog/issues/26006

### Description of changes
To avoid the issue we saw in PM cluster where Pods had apigroup set. Since data was defined outside, it leaked properties while looping. Moving the declaration inside. @zlayne 