### PR TITLE
remove kubeadmin workaround

### DIFF
--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -320,30 +320,30 @@ func (shared *SharedData) isClusterScoped(kindPlural, apigroup string) bool {
 	return ok
 }
 
-func setImpersonationUserInfo(user authv1.UserInfo) *rest.ImpersonationConfig {
+func setImpersonationUserInfo(userInfo authv1.UserInfo) *rest.ImpersonationConfig {
 	impersonConfig := &rest.ImpersonationConfig{}
 	// All fields in user info, if set, should be added to ImpersonationConfig. Otherwise SSRR won't work.
 	// All fields in UserInfo is optional. Set only if there is a value
 	//set username
-	if user.Username != "" {
-		impersonConfig.UserName = user.Username
+	if userInfo.Username != "" {
+		impersonConfig.UserName = userInfo.Username
 	}
 	//set uid
-	if user.UID != "" {
-		impersonConfig.UID = user.UID
+	if userInfo.UID != "" {
+		impersonConfig.UID = userInfo.UID
 	}
 	//set groups
-	if len(user.Groups) > 0 {
-		impersonConfig.Groups = user.Groups
+	if len(userInfo.Groups) > 0 {
+		impersonConfig.Groups = userInfo.Groups
 	}
-	if len(user.Extra) > 0 {
+	if len(userInfo.Extra) > 0 {
 		extraUpdated := map[string][]string{}
-		for key, val := range user.Extra {
+		for key, val := range userInfo.Extra {
 			extraUpdated[key] = val
 		}
 		impersonConfig.Extra = extraUpdated //set additional information
 	}
-	klog.V(9).Info("UserInfo available for impersonation is %+v:", user)
+	klog.V(9).Info("UserInfo available for impersonation is %+v:", userInfo)
 	return impersonConfig
 }
 

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -259,7 +259,7 @@ func (user *UserDataCache) getNamespacedResources(cache *Cache, ctx context.Cont
 			klog.V(9).Infof("SelfSubjectRulesReviews Kube API result for ns:%s : %v\n", ns, prettyPrint(result.Status))
 		}
 
-		// Name the loop - to break out of the loop if user is kubeadmin (have access to everything)
+		// Name the loop - to break out of the loop if user has access to everything (*)
 	resourceRulesLoop:
 		for _, rules := range result.Status.ResourceRules {
 			for _, verb := range rules.Verbs {

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	authv1 "k8s.io/api/authentication/v1"
 	authz "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -609,4 +610,21 @@ func Test_getUserData(t *testing.T) {
 	if len(result.ManagedClusters) != 2 {
 		t.Errorf("Expected 2 managed clusters but got %d", len(result.ManagedClusters))
 	}
+}
+
+func Test_setImpersonationUserInfo(t *testing.T) {
+
+	ui := authv1.UserInfo{
+		Username: "test-user",
+		UID:      "12345",
+		Groups:   []string{"group1"},
+		Extra: map[string]authv1.ExtraValue{
+			"extraKey": []string{"extraValue"}},
+	}
+
+	impConf := setImpersonationUserInfo(ui)
+	assert.Equal(t, ui.UID, impConf.UID)
+	assert.Equal(t, ui.Username, impConf.UserName)
+	assert.Equal(t, ui.Groups, impConf.Groups)
+	assert.Equal(t, len(ui.Extra), len(impConf.Extra))
 }

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -628,3 +628,17 @@ func Test_setImpersonationUserInfo(t *testing.T) {
 	assert.Equal(t, ui.Groups, impConf.Groups)
 	assert.Equal(t, len(ui.Extra), len(impConf.Extra))
 }
+
+func Test_getImpersonationClientSet(t *testing.T) {
+	mock_cache := mockNamespaceCache()
+	mock_cache = setupToken(mock_cache)
+
+	udc := &UserDataCache{
+		userData:     UserData{},
+		nsrUpdatedAt: time.Now(),
+	}
+	_, err := udc.getImpersonationClientSet("123456", mock_cache)
+	// Ensure that there is no error
+	assert.Nil(t, err)
+
+}

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -643,7 +643,7 @@ func Test_getImpersonationClientSet(t *testing.T) {
 
 }
 
-func Test_getNamespaces_kubeAdmin(t *testing.T) {
+func Test_hasAccessToAllResourcesInNamespace(t *testing.T) {
 	mock_cache := mockNamespaceCache()
 	mock_cache = setupToken(mock_cache)
 

--- a/pkg/resolver/related.go
+++ b/pkg/resolver/related.go
@@ -147,14 +147,12 @@ func (s *SearchResult) buildRelationsQuery() {
 	withoutRBACSql, _, withoutRBACSqlErr := relQueryInnerJoin.ToSQL()
 	klog.V(5).Info("Relations query before RBAC:", withoutRBACSql, withoutRBACSqlErr)
 
-	if s.userData != nil && !Iskubeadmin(s.context) {
+	if s.userData != nil {
 		// add rbac
 		relQueryWithRbac = relQueryInnerJoin.Where(buildRbacWhereClause(s.context, s.userData))
 	} else {
-		if !Iskubeadmin(s.context) {
-			panic(fmt.Sprintf("RBAC clause is required! None found for search relations query %+v for user %s ", s.input,
-				s.context.Value(rbac.ContextAuthTokenKey)))
-		}
+		panic(fmt.Sprintf("RBAC clause is required! None found for search relations query %+v for user %s ", s.input,
+			s.context.Value(rbac.ContextAuthTokenKey)))
 	}
 	sql, params, err := relQueryWithRbac.ToSQL()
 

--- a/pkg/resolver/searchComplete.go
+++ b/pkg/resolver/searchComplete.go
@@ -88,15 +88,12 @@ func (s *SearchCompleteResult) searchCompleteQuery(ctx context.Context) {
 			whereDs = append(whereDs, goqu.L(`"data"->?`, s.property).IsNotNull())
 		}
 		//RBAC CLAUSE
-		if s.userData != nil && !Iskubeadmin(ctx) {
-			// klog.Info("not adding rbac clause now")
+		if s.userData != nil {
 			whereDs = append(whereDs,
 				buildRbacWhereClause(ctx, s.userData)) // add rbac
 		} else {
-			if !Iskubeadmin(ctx) {
-				panic(fmt.Sprintf("RBAC clause is required! None found for searchComplete query %+v for user %s ",
-					s.input, ctx.Value(rbac.ContextAuthTokenKey)))
-			}
+			panic(fmt.Sprintf("RBAC clause is required! None found for searchComplete query %+v for user %s ",
+				s.input, ctx.Value(rbac.ContextAuthTokenKey)))
 		}
 		//Adding an arbitrarily high number 100000 as limit here in the inner query
 		// Adding a LIMIT helps to speed up the query

--- a/pkg/resolver/searchSchema.go
+++ b/pkg/resolver/searchSchema.go
@@ -56,13 +56,11 @@ func (s *SearchSchema) buildSearchSchemaQuery(ctx context.Context) {
 	//WHERE CLAUSE
 	var whereDs exp.ExpressionList
 
-	if s.userData != nil && !Iskubeadmin(ctx) {
+	if s.userData != nil {
 		whereDs = buildRbacWhereClause(ctx, s.userData) // add rbac
 	} else {
-		if !Iskubeadmin(ctx) {
-			panic(fmt.Sprintf("RBAC clause is required! None found for search schema query for user %s ",
-				ctx.Value(rbac.ContextAuthTokenKey)))
-		}
+		panic(fmt.Sprintf("RBAC clause is required! None found for search schema query for user %s ",
+			ctx.Value(rbac.ContextAuthTokenKey)))
 	}
 
 	//SELECT CLAUSE


### PR DESCRIPTION
Signed-off-by: Sherin Varughese <shvarugh@redhat.com>

**Related Issue:**  [stolostron/backlog#25996](https://github.com/stolostron/backlog/issues/25996)

### Description of changes
Remove rbac workaround for kubeadmin
For users to get the correct SSRR, all provided user info should be passed to impersonation config.
Just passing username and UID will not suffice to create the correct SSRR, if other info like groups and extra are present in token review.