### PR TITLE
Case insensitive keywords

### DIFF
--- a/pkg/resolver/search.go
+++ b/pkg/resolver/search.go
@@ -522,7 +522,7 @@ func WhereClauseFilter(input *model.SearchInput) []exp.Expression {
 		keywords := pointerToStringArray(input.Keywords)
 		for _, key := range keywords {
 			key = "%" + key + "%"
-			whereDs = append(whereDs, goqu.L(`"value"`).Like(key).Expression())
+			whereDs = append(whereDs, goqu.L(`"value"`).ILike(key).Expression())
 		}
 	}
 	if input.Filters != nil {

--- a/pkg/resolver/search_test.go
+++ b/pkg/resolver/search_test.go
@@ -388,7 +388,7 @@ func Test_SearchResolver_Keywords(t *testing.T) {
 	mockRows := newMockRowsWithoutRBAC("./mocks/mock.json", searchInput, "", 0)
 
 	mockPool.EXPECT().Query(gomock.Any(),
-		gomock.Eq(`SELECT DISTINCT "uid", "cluster", "data" FROM "search"."resources", jsonb_each_text("data") WHERE (("value" LIKE '%Template%') AND (("cluster" = ANY ('{}')) OR ((data->>'_hubClusterResource' = 'true') AND NULL))) LIMIT 10`),
+		gomock.Eq(`SELECT DISTINCT "uid", "cluster", "data" FROM "search"."resources", jsonb_each_text("data") WHERE (("value" ILIKE '%Template%') AND (("cluster" = ANY ('{}')) OR ((data->>'_hubClusterResource' = 'true') AND NULL))) LIMIT 10`),
 		gomock.Eq([]interface{}{}),
 	).Return(mockRows, nil)
 


### PR DESCRIPTION
Signed-off-by: Anxhela <acoba@redhat.com>

**Related Issue:**  stolostron/backlog#22013

### Description of changes
Users should be able to search by keyword without worrying about case sensitivity. This PR fixes current logic to use a case insensitive like clause