### PR TITLE
check if user has access to all resources

### DIFF
--- a/pkg/rbac/sharedData.go
+++ b/pkg/rbac/sharedData.go
@@ -102,7 +102,8 @@ func sharedCacheValid(shared *SharedData) bool {
 	return false
 }
 
-// Obtain all the cluster-scoped resources in the hub cluster that support list and watch.
+// Obtain all the cluster-scoped resources in the hub cluster that support list and watch
+// Get the list of resources in the database where namespace field is null.
 // Equivalent to: `oc api-resources -o wide | grep false | grep watch | grep list`
 func (shared *SharedData) GetClusterScopedResources(cache *Cache, ctx context.Context) error {
 
@@ -185,6 +186,8 @@ func (shared *SharedData) GetSharedNamespaces(cache *Cache, ctx context.Context)
 	return shared.nsErr
 }
 
+// Obtain all the managedclusters.
+// Equivalent to `oc get managedclusters`
 func (shared *SharedData) GetManagedClusters(cache *Cache, ctx context.Context) error {
 
 	shared.mcLock.Lock()
@@ -208,6 +211,7 @@ func (shared *SharedData) GetManagedClusters(cache *Cache, ctx context.Context) 
 	}
 
 	for _, item := range resourceObj.Items {
+		// Add to list if it is not local-cluster
 		if item.GetName() != "local-cluster" {
 			managedClusters[item.GetName()] = struct{}{}
 		}

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -232,10 +232,9 @@ func (user *UserDataCache) userAuthorizedListSSAR(ctx context.Context, authzClie
 	accessCheck := &authz.SelfSubjectAccessReview{
 		Spec: authz.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authz.ResourceAttributes{
-				Namespace: "*",
-				Verb:      "list",
-				Group:     apigroup,
-				Resource:  kind_plural,
+				Verb:     "list",
+				Group:    apigroup,
+				Resource: kind_plural,
 			},
 		},
 	}

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -74,9 +74,9 @@ func (cache *Cache) GetUserDataCache(ctx context.Context,
 	var user *UserDataCache
 	var uid string
 	var err error
-
+	var userInfo authv1.UserInfo
 	// get uid from tokenreview
-	if uid, _ = cache.GetUserUID(ctx); uid == "noUidFound" {
+	if uid, userInfo = cache.GetUserUID(ctx); uid == "noUidFound" {
 		return user, fmt.Errorf("cannot find user with uid: %s", uid)
 	}
 	clientToken := ctx.Value(ContextAuthTokenKey).(string)
@@ -108,6 +108,19 @@ func (cache *Cache) GetUserDataCache(ctx context.Context,
 		}
 	}
 
+	// Before checking each namespace and clusterscoped resource, check if user has access to everything
+	userHasAllAccess, err := user.userHasAllAccess(cache, ctx, clientToken)
+	if err != nil {
+		klog.Warning("Encountered error while checking if user has access to everything ", err)
+	} else {
+		if userHasAllAccess {
+			klog.Infof("User %s with uid %s has access to all resources.", userInfo.Username, userInfo.UID)
+			return user, nil
+		}
+		klog.Infof("User %s with uid %s doesn't have access to all resources. Checking individually",
+			userInfo.Username, userInfo.UID)
+	}
+
 	userDataCache, err := user.getNamespacedResources(cache, ctx, clientToken)
 
 	// Get cluster scoped resources for the user
@@ -118,6 +131,32 @@ func (cache *Cache) GetUserDataCache(ctx context.Context,
 		userDataCache, err = user.getClusterScopedResources(cache, ctx, clientToken)
 	}
 	return userDataCache, err
+}
+
+func (user *UserDataCache) userHasAllAccess(cache *Cache, ctx context.Context, clientToken string) (bool, error) {
+	impersClientset, err := user.getImpersonationClientSet(clientToken, cache)
+	if err != nil {
+		klog.Warning("Error creating clientset with impersonation config.", err.Error())
+		return false, err
+	}
+	//If we have a new set of authorized list for the user reset the previous one
+	if user.userAuthorizedListSSAR(ctx, impersClientset, "*", "*") {
+		user.csrLock.Lock()
+		defer user.csrLock.Unlock()
+		user.userData.CsResources = []Resource{{Apigroup: "*", Kind: "*"}}
+		user.csrUpdatedAt = time.Now()
+
+		user.nsrLock.Lock()
+		defer user.nsrLock.Unlock()
+		user.userData.NsResources = map[string][]Resource{"*": {{Apigroup: "*", Kind: "*"}}}
+		user.nsrUpdatedAt = time.Now()
+
+		user.userData.ManagedClusters = cache.shared.managedClusters
+		user.clustersUpdatedAt = time.Now()
+		user.csrErr, user.nsrErr, user.clustersErr = nil, nil, nil
+		return true, nil
+	}
+	return false, nil
 }
 
 // Get a static copy of the current user data. It will use cached data if valid or refresh if needed.
@@ -174,7 +213,7 @@ func (user *UserDataCache) getClusterScopedResources(cache *Cache, ctx context.C
 	//If we have a new set of authorized list for the user reset the previous one
 	user.userData.CsResources = nil
 	for res := range clusterScopedResources {
-		if user.userAuthorizedListCSResource(ctx, impersClientset, res.Apigroup, res.Kind) {
+		if user.userAuthorizedListSSAR(ctx, impersClientset, res.Apigroup, res.Kind) {
 			user.userData.CsResources = append(user.userData.CsResources,
 				Resource{Apigroup: res.Apigroup, Kind: res.Kind})
 		}
@@ -186,14 +225,15 @@ func (user *UserDataCache) getClusterScopedResources(cache *Cache, ctx context.C
 	return user, user.csrErr
 }
 
-func (user *UserDataCache) userAuthorizedListCSResource(ctx context.Context, authzClient v1.AuthorizationV1Interface,
+func (user *UserDataCache) userAuthorizedListSSAR(ctx context.Context, authzClient v1.AuthorizationV1Interface,
 	apigroup string, kind_plural string) bool {
 	accessCheck := &authz.SelfSubjectAccessReview{
 		Spec: authz.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authz.ResourceAttributes{
-				Verb:     "list",
-				Group:    apigroup,
-				Resource: kind_plural,
+				Namespace: "*",
+				Verb:      "list",
+				Group:     apigroup,
+				Resource:  kind_plural,
 			},
 		},
 	}
@@ -274,7 +314,7 @@ func (user *UserDataCache) getNamespacedResources(cache *Cache, ctx context.Cont
 	resourceRulesLoop:
 		for _, rules := range result.Status.ResourceRules {
 			for _, verb := range rules.Verbs {
-				if verb == "list" || verb == "*" { //TODO: resourceName == "*" && verb == "*" then exit loop
+				if verb == "list" || verb == "*" {
 					for _, res := range rules.Resources {
 						for _, api := range rules.APIGroups {
 							//Add the resource if it is not cluster scoped

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
+impersonationConfigCreationerror := "Error creating clientset with impersonation config"
 // Contains data about the resources the user is allowed to access.
 type UserDataCache struct {
 	userData UserData
@@ -136,7 +137,7 @@ func (cache *Cache) GetUserDataCache(ctx context.Context,
 func (user *UserDataCache) userHasAllAccess(cache *Cache, ctx context.Context, clientToken string) (bool, error) {
 	impersClientset, err := user.getImpersonationClientSet(clientToken, cache)
 	if err != nil {
-		klog.Warning("Error creating clientset with impersonation config.", err.Error())
+		klog.Warning(impersonationConfigCreationerror, err.Error())
 		return false, err
 	}
 	//If we have a new set of authorized list for the user reset the previous one
@@ -207,7 +208,7 @@ func (user *UserDataCache) getClusterScopedResources(cache *Cache, ctx context.C
 	impersClientset, err := user.getImpersonationClientSet(clientToken, cache)
 	if err != nil {
 		user.csrErr = err
-		klog.Warning("Error creating clientset with impersonation config.", err.Error())
+		klog.Warning(impersonationConfigCreationerror, err.Error())
 		return user, user.csrErr
 	}
 	//If we have a new set of authorized list for the user reset the previous one
@@ -289,7 +290,7 @@ func (user *UserDataCache) getNamespacedResources(cache *Cache, ctx context.Cont
 
 	impersClientset, err := user.getImpersonationClientSet(clientToken, cache)
 	if err != nil {
-		klog.Warning("Error creating clientset with impersonation config.", err.Error())
+		klog.Warning(impersonationConfigCreationerror, err.Error())
 		return user, err
 	}
 

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -116,10 +116,10 @@ func (cache *Cache) GetUserDataCache(ctx context.Context,
 		klog.Warning("Encountered error while checking if user has access to everything ", err)
 	} else {
 		if userHasAllAccess {
-			klog.Infof("User %s with uid %s has access to all resources.", userInfo.Username, userInfo.UID)
+			klog.V(4).Infof("User %s with uid %s has access to all resources.", userInfo.Username, userInfo.UID)
 			return user, nil
 		}
-		klog.Infof("User %s with uid %s doesn't have access to all resources. Checking individually",
+		klog.V(5).Infof("User %s with uid %s doesn't have access to all resources. Checking individually",
 			userInfo.Username, userInfo.UID)
 	}
 

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -18,7 +18,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
-impersonationConfigCreationerror := "Error creating clientset with impersonation config"
+var impersonationConfigCreationerror = "Error creating clientset with impersonation config"
+
 // Contains data about the resources the user is allowed to access.
 type UserDataCache struct {
 	userData UserData

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -2,6 +2,7 @@ package rbac
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -83,8 +84,11 @@ func Test_getNamespaces_emptyCache(t *testing.T) {
 			},
 		},
 	}
-	fs := fake.NewSimpleClientset()
-	fs.PrependReactor("create", "*", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+	fs := fake.Clientset{}
+	fs.AddReactor("create", "selfsubjectaccessreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("Error creating ssar")
+	})
+	fs.AddReactor("create", "selfsubjectrulesreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
 		ret = action.(testingk8s.CreateAction).GetObject()
 		_, ok := ret.(metav1.Object)
 		if !ok {
@@ -213,8 +217,11 @@ func Test_getNamespaces_expiredCache(t *testing.T) {
 			},
 		},
 	}
-	fs := fake.NewSimpleClientset()
-	fs.PrependReactor("create", "*", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+	fs := fake.Clientset{}
+	fs.AddReactor("create", "selfsubjectaccessreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("Error creating ssar")
+	})
+	fs.AddReactor("create", "selfsubjectrulesreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
 		ret = action.(testingk8s.CreateAction).GetObject()
 		_, ok := ret.(metav1.Object)
 		if !ok {
@@ -392,8 +399,11 @@ func Test_managedClusters_emptyCache(t *testing.T) {
 		},
 	}
 
-	fs := fake.NewSimpleClientset()
-	fs.PrependReactor("create", "*", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+	fs := fake.Clientset{}
+	fs.AddReactor("create", "selfsubjectaccessreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("Error creating ssar")
+	})
+	fs.AddReactor("create", "selfsubjectrulesreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
 		ret = action.(testingk8s.CreateAction).GetObject()
 		meta, ok := ret.(metav1.Object)
 		if !ok {
@@ -500,8 +510,11 @@ func Test_managedCluster_expiredCache(t *testing.T) {
 		},
 	}
 
-	fs := fake.NewSimpleClientset()
-	fs.PrependReactor("create", "*", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+	fs := fake.Clientset{}
+	fs.AddReactor("create", "selfsubjectaccessreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("Error creating ssar")
+	})
+	fs.AddReactor("create", "selfsubjectrulesreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
 		ret = action.(testingk8s.CreateAction).GetObject()
 		meta, ok := ret.(metav1.Object)
 		if !ok {
@@ -665,8 +678,11 @@ func Test_hasAccessToAllResourcesInNamespace(t *testing.T) {
 			},
 		},
 	}
-	fs := fake.NewSimpleClientset()
-	fs.PrependReactor("create", "*", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+	fs := fake.Clientset{}
+	fs.AddReactor("create", "selfsubjectaccessreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("Error creating ssar")
+	})
+	fs.AddReactor("create", "selfsubjectrulesreviews", func(action testingk8s.Action) (handled bool, ret runtime.Object, err error) {
 		ret = action.(testingk8s.CreateAction).GetObject()
 		_, ok := ret.(metav1.Object)
 		if !ok {

--- a/pkg/resolver/rbacHelper.go
+++ b/pkg/resolver/rbacHelper.go
@@ -6,6 +6,8 @@ import (
 	"github.com/doug-martin/goqu/v9/exp"
 	"github.com/lib/pq"
 	"github.com/stolostron/search-v2-api/pkg/rbac"
+	v1 "k8s.io/api/authentication/v1"
+	"k8s.io/klog/v2"
 )
 
 // function to loop through resources and build the where clause
@@ -45,8 +47,16 @@ func matchApigroupKind(resources []rbac.Resource) exp.ExpressionList {
 // Match cluster-scoped resources, which are identified by not having the namespace property.
 // Resolves to something like:
 //   (AND data->>'namespace' = '')
-func matchClusterScopedResources(csRes []rbac.Resource) exp.ExpressionList {
+func matchClusterScopedResources(csRes []rbac.Resource, userInfo v1.UserInfo) exp.ExpressionList {
 	if len(csRes) > 0 {
+		// user has access to all cluster scoped resources
+		if len(csRes) == 1 && csRes[0].Apigroup == "*" && csRes[0].Kind == "*" {
+
+			klog.V(5).Infof(
+				"User %s with UID %s has access to all clusterscoped resources. Excluding cluster scoped filters",
+				userInfo.Username, userInfo.UID)
+			return goqu.And()
+		}
 		return goqu.And(goqu.COALESCE(goqu.L(`data->>?`, "namespace"), "").Eq(""),
 			matchApigroupKind(csRes))
 
@@ -58,11 +68,18 @@ func matchClusterScopedResources(csRes []rbac.Resource) exp.ExpressionList {
 // Resolves to some similar to:
 //    (namespace = 'a' AND ((apigroup='' AND kind='') OR (apigroup='' AND kind='') OR ... ) OR
 //    (namespace = 'b' AND ( ... ) OR (namespace = 'c' AND ( ... ) OR ...
-func matchNamespacedResources(nsResources map[string][]rbac.Resource) exp.ExpressionList {
+func matchNamespacedResources(nsResources map[string][]rbac.Resource, userInfo v1.UserInfo) exp.ExpressionList {
 	var whereNsDs []exp.Expression
 	if len(nsResources) > 0 {
 		whereNsDs = make([]exp.Expression, len(nsResources))
 		namespaces := getKeys(nsResources)
+
+		// user has access to all namespaces
+		if len(namespaces) == 1 && namespaces[0] == "*" {
+			klog.V(5).Infof("User %s with UID %s has access to all namespaces. Excluding individual namespace filters",
+				userInfo.Username, userInfo.UID)
+			return goqu.Or()
+		}
 
 		for nsCount, namespace := range namespaces {
 			whereNsDs[nsCount] = goqu.And(goqu.L(`data->>?`, "namespace").Eq(namespace),

--- a/pkg/resolver/searchComplete.go
+++ b/pkg/resolver/searchComplete.go
@@ -87,10 +87,14 @@ func (s *SearchCompleteResult) searchCompleteQuery(ctx context.Context) {
 			//Adding notNull clause to filter out NULL values and ORDER by sort results
 			whereDs = append(whereDs, goqu.L(`"data"->?`, s.property).IsNotNull())
 		}
+
+		//get user info for logging
+		_, userInfo := rbac.GetCache().GetUserUID(ctx)
+
 		//RBAC CLAUSE
 		if s.userData != nil {
 			whereDs = append(whereDs,
-				buildRbacWhereClause(ctx, s.userData)) // add rbac
+				buildRbacWhereClause(ctx, s.userData, userInfo)) // add rbac
 		} else {
 			panic(fmt.Sprintf("RBAC clause is required! None found for searchComplete query %+v for user %s ",
 				s.input, ctx.Value(rbac.ContextAuthTokenKey)))

--- a/pkg/resolver/searchSchema.go
+++ b/pkg/resolver/searchSchema.go
@@ -56,8 +56,11 @@ func (s *SearchSchema) buildSearchSchemaQuery(ctx context.Context) {
 	//WHERE CLAUSE
 	var whereDs exp.ExpressionList
 
+	//get user info for logging
+	_, userInfo := rbac.GetCache().GetUserUID(ctx)
+
 	if s.userData != nil {
-		whereDs = buildRbacWhereClause(ctx, s.userData) // add rbac
+		whereDs = buildRbacWhereClause(ctx, s.userData, userInfo) // add rbac
 	} else {
 		panic(fmt.Sprintf("RBAC clause is required! None found for search schema query for user %s ",
 			ctx.Value(rbac.ContextAuthTokenKey)))

--- a/pkg/resolver/search_test.go
+++ b/pkg/resolver/search_test.go
@@ -562,3 +562,41 @@ func Test_buildRbacWhereClauseHandleAllStars(t *testing.T) {
 	gotSql, _, _ := goqu.Select().Where(rbacCombined).ToSQL()
 	assert.Equal(t, expectedSql, gotSql)
 }
+
+func Test_SearchResolver_UidsAllAccess(t *testing.T) {
+	// Create a SearchResolver instance with a mock connection pool.
+	val1 := "template"
+	searchInput := &model.SearchInput{Filters: []*model.SearchFilter{{Property: "kind", Values: []*string{&val1}}}}
+	resolver, mockPool := newMockSearchResolver(t, searchInput, nil, &rbac.UserData{
+		CsResources:     []rbac.Resource{{Apigroup: "*", Kind: "*"}},
+		NsResources:     map[string][]rbac.Resource{"*": {{Apigroup: "*", Kind: "*"}}},
+		ManagedClusters: map[string]struct{}{"managed-cluster1": {}},
+	},
+	)
+	// Mock the database queries.
+	mockRows := newMockRowsWithoutRBAC("./mocks/mock.json", searchInput, "", 0)
+
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(`SELECT "uid" FROM "search"."resources" WHERE (("data"->>'kind' ILIKE ANY ('{"template"}')) AND (("cluster" = ANY ('{"managed-cluster1"}')) OR (data->>'_hubClusterResource' = 'true'))) LIMIT 1000`),
+		gomock.Eq([]interface{}{}),
+	).Return(mockRows, nil)
+
+	// Execute the function
+	resolver.Uids()
+
+	// Verify returned items.
+	if len(resolver.uids) != len(mockRows.mockData) {
+		t.Errorf("Items() received incorrect number of items. Expected %d Got: %d", len(mockRows.mockData), len(resolver.uids))
+	}
+
+	// Verify properties for each returned item.
+	for i, item := range resolver.uids {
+		mockRow := mockRows.mockData[i]
+		expectedRow := formatDataMap(mockRow["data"].(map[string]interface{}))
+		expectedRow["_uid"] = mockRow["uid"]
+
+		if *item != mockRow["uid"].(string) {
+			t.Errorf("Value of key [uid] does not match for item [%d].\nExpected: %s\nGot: %s", i, expectedRow["_uid"], *item)
+		}
+	}
+}

--- a/pkg/resolver/testHelper_test.go
+++ b/pkg/resolver/testHelper_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jackc/pgproto3/v2"
 	"github.com/stolostron/search-v2-api/graph/model"
 	"github.com/stolostron/search-v2-api/pkg/rbac"
+	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -32,6 +33,12 @@ func newUserData() ([]rbac.Resource, map[string][]rbac.Resource, map[string]stru
 	return csres, nsScopeAccess, managedClusters
 }
 
+func getUserInfo() authv1.UserInfo {
+	return authv1.UserInfo{
+		UID:      "unique-user-id",
+		Username: "unique-username",
+	}
+}
 func newMockSearchResolver(t *testing.T, input *model.SearchInput, uids []*string, ud *rbac.UserData) (*SearchResult, *pgxpoolmock.MockPgxPool) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Signed-off-by: Sherin Varughese <shvarugh@redhat.com>

**Related Issue:**  stolostron/backlog#22013 - Optimize RBAC for kubeadmin level access

### Description of changes
Before creating SSRR and SSAR for each namespace and resource - check if user has kubeadmin level access/access to all resources. This will bypass ns level checks and make it easier for kubeadmin level  users.