### PR TITLE
Fixes null related items and case of kind property

### DIFF
--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -28,7 +28,7 @@ func initializePool() {
 	)
 
 	// Remove password from connection log.
-	redactedDbConn := strings.ReplaceAll(dbConnString, cfg.DBPass, "[REDACTED]")
+	redactedDbConn := strings.ReplaceAll(dbConnString, "password="+cfg.DBPass, "password=[REDACTED]")
 	klog.Infof("Connecting to PostgreSQL using: %s", redactedDbConn)
 
 	config, configErr := pgxpool.ParseConfig(dbConnString)
@@ -38,7 +38,7 @@ func initializePool() {
 
 	conn, err := pgxpool.ConnectConfig(context.TODO(), config)
 	if err != nil {
-		klog.Error("Unable to connect to database: %+v\n", err)
+		klog.Errorf("Unable to connect to database: %+v\n", err)
 		metric.DBConnectionFailed.WithLabelValues("DBConnect").Inc()
 	}
 

--- a/pkg/resolver/mocks/mock-related-test.json
+++ b/pkg/resolver/mocks/mock-related-test.json
@@ -1,0 +1,34 @@
+{
+    "columns": ["uid", "cluster", "data"],
+    "records":[
+    {
+        "uid":"local-cluster/30c35f12-320a-417f-98d1-fbee28a4b2a6",
+        "resourceString":"configmaps",
+        "properties":{
+            "_clusterNamespace":"local-cluster-ns",
+            "_hubClusterResource":true,
+            "apigroup":"",
+            "apiversion":"v1",
+            "created":"2021-07-14T10:20:37Z",
+            "kind":"ConfigMap",
+            "label":{"mock-label":"true"},
+            "name":"mock-configmap",
+            "namespace":"default"
+        }
+    },
+    {
+        "uid":"local-cluster/411e30e4-f773-41a6-b745-24c93c173f45",
+        "resourceString":"deployments",
+        "properties":{
+            "_clusterNamespace":"local-cluster-ns",
+            "_hubClusterResource":true,
+            "apigroup":"",
+            "apiversion":"v1",
+            "created":"2021-07-14T10:20:37Z",
+            "kind":"Deployment",
+            "label":{"samples.operator.openshift.io/managed":"true"},
+            "name":"mock-deployment",
+            "namespace":"default"
+        }
+    }]
+} 

--- a/pkg/resolver/related.go
+++ b/pkg/resolver/related.go
@@ -283,7 +283,7 @@ func (s *SearchResult) filterRelatedUIDs(levelsMap map[string][]string) {
 	s.uids = []*string{}
 
 	// If relatedKinds filter is empty, include all.
-	if len(s.input.RelatedKinds) == 0 {
+	if s.input.RelatedKinds == nil || len(s.input.RelatedKinds) == 0 {
 		for _, values := range levelsMap {
 			s.uids = append(s.uids, stringArrayToPointer(values)...)
 		}

--- a/pkg/resolver/related_test.go
+++ b/pkg/resolver/related_test.go
@@ -14,28 +14,34 @@ import (
 
 func Test_SearchResolver_Relationships(t *testing.T) {
 	config.Cfg.RelationLevel = 3
-	var resultList []*string
 
+	// Build a mock SearchResolver{} using uids as filter input.
 	uid1 := "local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd"
 	uid2 := "local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b"
-
-	resultList = append(resultList, &uid1, &uid2)
-
-	// take the uids from above as input
+	resultList := []*string{&uid1, &uid2}
 	searchInput := &model.SearchInput{Filters: []*model.SearchFilter{{Property: "uid", Values: resultList}}}
-	ud := rbac.UserData{}
+	resolver, mockPool := newMockSearchResolver(t, searchInput, resultList, &rbac.UserData{}, nil)
 
-	resolver, mockPool2 := newMockSearchResolver(t, searchInput, resultList, &ud, nil)
-
-	relQuery := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (WITH RECURSIVE search_graph(level, sourceid, destid,  sourcekind, destkind, cluster) AS (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')) OR ("sourceid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) UNION (SELECT level+1 AS "level", "e"."sourceid", "e"."destid", "e"."sourcekind", "e"."destkind", "e"."cluster" FROM "search"."edges" AS "e" INNER JOIN "search_graph" AS "sg" ON (("sg"."destid" IN ("e"."sourceid", "e"."destid")) OR ("sg"."sourceid" IN ("e"."sourceid", "e"."destid"))) WHERE (("e"."destkind" NOT IN ('Node', 'Channel')) AND ("e"."sourcekind" NOT IN ('Node', 'Channel')) AND ("sg"."level" <= 3)))) SELECT DISTINCT "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search_graph") AS "search_graph") AS "combineIds" WHERE (("level" <= 3) AND ("uid" NOT IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) GROUP BY "uid", "kind") AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{}')) OR ((data->>'_hubClusterResource' = 'true') AND NULL))`)
-
+	// Mock FIRST ddatabase request.
+	query := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (WITH RECURSIVE search_graph(level, sourceid, destid,  sourcekind, destkind, cluster) AS (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')) OR ("sourceid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) UNION (SELECT level+1 AS "level", "e"."sourceid", "e"."destid", "e"."sourcekind", "e"."destkind", "e"."cluster" FROM "search"."edges" AS "e" INNER JOIN "search_graph" AS "sg" ON (("sg"."destid" IN ("e"."sourceid", "e"."destid")) OR ("sg"."sourceid" IN ("e"."sourceid", "e"."destid"))) WHERE (("e"."destkind" NOT IN ('Node', 'Channel')) AND ("e"."sourcekind" NOT IN ('Node', 'Channel')) AND ("sg"."level" <= 3)))) SELECT DISTINCT "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search_graph") AS "search_graph") AS "combineIds" WHERE (("level" <= 3) AND ("uid" NOT IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) GROUP BY "uid", "kind") AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{}')) OR ((data->>'_hubClusterResource' = 'true') AND NULL))`)
 	mockRows := newMockRowsWithoutRBAC("./mocks/mock-rel-1.json", searchInput, "", 0)
-	mockPool2.EXPECT().Query(gomock.Any(),
-		gomock.Eq(relQuery),
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query),
 		gomock.Eq([]interface{}{}),
 	).Return(mockRows, nil)
 
-	result := resolver.Related(context.Background()) // this should return a relatedResults object
+	// Mock SECOND ddatabase request.
+	query2 := `SELECT "uid", "cluster", "data" FROM "search"."resources" WHERE ("uid" IN ('local-cluster/411e30e4-f773-41a6-b745-24c93c173f45', 'local-cluster/30c35f12-320a-417f-98d1-fbee28a4b2a6')) LIMIT 1000`
+	mockRows2 := newMockRows("./mocks/mock-related-test.json")
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query2),
+		gomock.Any(),
+	).Return(mockRows2, nil)
+
+	// Execute the function - should return a relatedResults object
+	result := resolver.Related(context.Background())
+
+	// Verify expected and result kinds
 	resultKinds := make([]*string, len(result))
 	for i, data := range result {
 		kind := data.Kind
@@ -47,38 +53,44 @@ func Test_SearchResolver_Relationships(t *testing.T) {
 		destKind, _ := data["kind"].(string)
 		expectedKinds[i] = &destKind
 	}
-	// Verify expected and result kinds
+
 	AssertStringArrayEqual(t, resultKinds, expectedKinds, "Error in expected destKinds in Test_SearchResolver_Relationships")
 
 	// Verify returned items.
 	if len(result) != len(mockRows.mockData) {
 		t.Errorf("Items() received incorrect number of items. Expected %d Got: %d", len(mockRows.mockData), len(result))
 	}
-
 }
 
 func Test_SearchResolver_RelationshipsWithCluster(t *testing.T) {
 	config.Cfg.RelationLevel = 3
-	var resultList []*string
 
+	// Build a mock SearchResolver{} using uids as filter input.
 	uid1 := "cluster__local-cluster"
+	resultList := []*string{&uid1}
 	csRes, nsRes, mc := newUserData()
 	ud := rbac.UserData{CsResources: csRes, NsResources: nsRes, ManagedClusters: mc}
-	resultList = append(resultList, &uid1)
-
-	// take the uids from above as input
 	searchInput := &model.SearchInput{Filters: []*model.SearchFilter{{Property: "kind", Values: resultList}}}
-	resolver, mockPool2 := newMockSearchResolver(t, searchInput, resultList, &ud, nil)
+	resolver, mockPool := newMockSearchResolver(t, searchInput, resultList, &ud, nil)
 
-	relQuery := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (WITH RECURSIVE search_graph(level, sourceid, destid,  sourcekind, destkind, cluster) AS (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('cluster__local-cluster')) OR ("sourceid" IN ('cluster__local-cluster'))) UNION (SELECT level+1 AS "level", "e"."sourceid", "e"."destid", "e"."sourcekind", "e"."destkind", "e"."cluster" FROM "search"."edges" AS "e" INNER JOIN "search_graph" AS "sg" ON (("sg"."destid" IN ("e"."sourceid", "e"."destid")) OR ("sg"."sourceid" IN ("e"."sourceid", "e"."destid"))) WHERE (("e"."destkind" NOT IN ('Node', 'Channel')) AND ("e"."sourcekind" NOT IN ('Node', 'Channel')) AND ("sg"."level" <= 3)))) SELECT DISTINCT "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search_graph") AS "search_graph") AS "combineIds" WHERE (("level" <= 3) AND ("uid" NOT IN ('cluster__local-cluster'))) GROUP BY "uid", "kind" UNION (SELECT "uid" AS "uid", data->>'kind' AS "kind", 1 AS "level" FROM "search"."resources" WHERE ("cluster" IN ('local-cluster')))) AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{"managed1","managed2"}')) OR ((data->>'_hubClusterResource' = 'true') AND (((COALESCE(data->>'namespace', '') = '') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'nodes')) OR ((COALESCE(data->>'apigroup', '') = 'storage.k8s.io') AND (data->>'kind_plural' = 'csinodes')))) OR (((data->>'namespace' = 'default') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'configmaps')) OR ((COALESCE(data->>'apigroup', '') = 'v4') AND (data->>'kind_plural' = 'services')))) OR ((data->>'namespace' = 'ocm') AND (((COALESCE(data->>'apigroup', '') = 'v1') AND (data->>'kind_plural' = 'pods')) OR ((COALESCE(data->>'apigroup', '') = 'v2') AND (data->>'kind_plural' = 'deployments'))))))))`)
-
+	// Mock FIRST ddatabase request.
+	query1 := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (WITH RECURSIVE search_graph(level, sourceid, destid,  sourcekind, destkind, cluster) AS (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('cluster__local-cluster')) OR ("sourceid" IN ('cluster__local-cluster'))) UNION (SELECT level+1 AS "level", "e"."sourceid", "e"."destid", "e"."sourcekind", "e"."destkind", "e"."cluster" FROM "search"."edges" AS "e" INNER JOIN "search_graph" AS "sg" ON (("sg"."destid" IN ("e"."sourceid", "e"."destid")) OR ("sg"."sourceid" IN ("e"."sourceid", "e"."destid"))) WHERE (("e"."destkind" NOT IN ('Node', 'Channel')) AND ("e"."sourcekind" NOT IN ('Node', 'Channel')) AND ("sg"."level" <= 3)))) SELECT DISTINCT "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search_graph") AS "search_graph") AS "combineIds" WHERE (("level" <= 3) AND ("uid" NOT IN ('cluster__local-cluster'))) GROUP BY "uid", "kind" UNION (SELECT "uid" AS "uid", data->>'kind' AS "kind", 1 AS "level" FROM "search"."resources" WHERE ("cluster" IN ('local-cluster')))) AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{"managed1","managed2"}')) OR ((data->>'_hubClusterResource' = 'true') AND (((COALESCE(data->>'namespace', '') = '') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'nodes')) OR ((COALESCE(data->>'apigroup', '') = 'storage.k8s.io') AND (data->>'kind_plural' = 'csinodes')))) OR (((data->>'namespace' = 'default') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'configmaps')) OR ((COALESCE(data->>'apigroup', '') = 'v4') AND (data->>'kind_plural' = 'services')))) OR ((data->>'namespace' = 'ocm') AND (((COALESCE(data->>'apigroup', '') = 'v1') AND (data->>'kind_plural' = 'pods')) OR ((COALESCE(data->>'apigroup', '') = 'v2') AND (data->>'kind_plural' = 'deployments'))))))))`)
 	mockRows := newMockRowsWithoutRBAC("./mocks/mock-rel-1.json", searchInput, "", 0)
-	mockPool2.EXPECT().Query(gomock.Any(),
-		gomock.Eq(relQuery),
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query1),
 		gomock.Eq([]interface{}{}),
 	).Return(mockRows, nil)
 
-	result := resolver.Related(context.Background()) // this should return a relatedResults object
+	// Mock the SECOND database request.
+	query2 := `SELECT "uid", "cluster", "data" FROM "search"."resources" WHERE ("uid" IN ('local-cluster/411e30e4-f773-41a6-b745-24c93c173f45', 'local-cluster/30c35f12-320a-417f-98d1-fbee28a4b2a6')) LIMIT 1000`
+	mockRows2 := newMockRows("./mocks/mock-related-test.json")
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query2),
+		gomock.Any(),
+	).Return(mockRows2, nil)
+
+	// Execute the function - should return a relatedResults object
+	result := resolver.Related(context.Background())
 
 	resultKinds := make([]*string, len(result))
 	for i, data := range result {
@@ -98,47 +110,44 @@ func Test_SearchResolver_RelationshipsWithCluster(t *testing.T) {
 	if len(result) != len(mockRows.mockData) {
 		t.Errorf("Items() received incorrect number of items. Expected %d Got: %d", len(mockRows.mockData), len(result))
 	}
-
 }
+
 func Test_SearchResolver_RelatedKindsRelationships(t *testing.T) {
 	config.Cfg.RelationLevel = 3
 
-	var resultList []*string
+	// Build a mock SearchResolver{} using uids as filter input.
 	uid1 := "local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd"
 	uid2 := "local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b"
-
-	resultList = append(resultList, &uid1, &uid2)
-	relatedKind1 := "ConfigMap"
+	resultList := []*string{&uid1, &uid2}
+	relatedKind := "ConfigMap"
 	csRes, nsRes, mc := newUserData()
 	ud := rbac.UserData{CsResources: csRes, NsResources: nsRes, ManagedClusters: mc}
-	// take the uids from above as input
-	searchInput2 := &model.SearchInput{RelatedKinds: []*string{&relatedKind1}, Filters: []*model.SearchFilter{{Property: "uid", Values: resultList}}}
+	searchInput := &model.SearchInput{RelatedKinds: []*string{&relatedKind}, Filters: []*model.SearchFilter{{Property: "uid", Values: resultList}}}
+	resolver, mockPool := newMockSearchResolver(t, searchInput, resultList, &ud, nil)
 
-	resolver, mockPool2 := newMockSearchResolver(t, searchInput2, resultList, &ud, nil)
-
-	relQuery := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (WITH RECURSIVE search_graph(level, sourceid, destid,  sourcekind, destkind, cluster) AS (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')) OR ("sourceid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) UNION (SELECT level+1 AS "level", "e"."sourceid", "e"."destid", "e"."sourcekind", "e"."destkind", "e"."cluster" FROM "search"."edges" AS "e" INNER JOIN "search_graph" AS "sg" ON (("sg"."destid" IN ("e"."sourceid", "e"."destid")) OR ("sg"."sourceid" IN ("e"."sourceid", "e"."destid"))) WHERE (("e"."destkind" NOT IN ('Node', 'Channel')) AND ("e"."sourcekind" NOT IN ('Node', 'Channel')) AND ("sg"."level" <= 3)))) SELECT DISTINCT "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search_graph") AS "search_graph") AS "combineIds" WHERE (("level" <= 3) AND ("uid" NOT IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) GROUP BY "uid", "kind") AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{"managed1","managed2"}')) OR ((data->>'_hubClusterResource' = 'true') AND (((COALESCE(data->>'namespace', '') = '') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'nodes')) OR ((COALESCE(data->>'apigroup', '') = 'storage.k8s.io') AND (data->>'kind_plural' = 'csinodes')))) OR (((data->>'namespace' = 'default') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'configmaps')) OR ((COALESCE(data->>'apigroup', '') = 'v4') AND (data->>'kind_plural' = 'services')))) OR ((data->>'namespace' = 'ocm') AND (((COALESCE(data->>'apigroup', '') = 'v1') AND (data->>'kind_plural' = 'pods')) OR ((COALESCE(data->>'apigroup', '') = 'v2') AND (data->>'kind_plural' = 'deployments'))))))))`)
-
-	mockRows := newMockRowsWithoutRBAC("./mocks/mock-rel-1.json", searchInput2, "", 0)
-	mockPool2.EXPECT().Query(gomock.Any(),
-		gomock.Eq(relQuery),
+	// Mock the FIRST database request.
+	query1 := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (WITH RECURSIVE search_graph(level, sourceid, destid,  sourcekind, destkind, cluster) AS (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')) OR ("sourceid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) UNION (SELECT level+1 AS "level", "e"."sourceid", "e"."destid", "e"."sourcekind", "e"."destkind", "e"."cluster" FROM "search"."edges" AS "e" INNER JOIN "search_graph" AS "sg" ON (("sg"."destid" IN ("e"."sourceid", "e"."destid")) OR ("sg"."sourceid" IN ("e"."sourceid", "e"."destid"))) WHERE (("e"."destkind" NOT IN ('Node', 'Channel')) AND ("e"."sourcekind" NOT IN ('Node', 'Channel')) AND ("sg"."level" <= 3)))) SELECT DISTINCT "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search_graph") AS "search_graph") AS "combineIds" WHERE (("level" <= 3) AND ("uid" NOT IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) GROUP BY "uid", "kind") AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{"managed1","managed2"}')) OR ((data->>'_hubClusterResource' = 'true') AND (((COALESCE(data->>'namespace', '') = '') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'nodes')) OR ((COALESCE(data->>'apigroup', '') = 'storage.k8s.io') AND (data->>'kind_plural' = 'csinodes')))) OR (((data->>'namespace' = 'default') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'configmaps')) OR ((COALESCE(data->>'apigroup', '') = 'v4') AND (data->>'kind_plural' = 'services')))) OR ((data->>'namespace' = 'ocm') AND (((COALESCE(data->>'apigroup', '') = 'v1') AND (data->>'kind_plural' = 'pods')) OR ((COALESCE(data->>'apigroup', '') = 'v2') AND (data->>'kind_plural' = 'deployments'))))))))`)
+	mockRows := newMockRowsWithoutRBAC("./mocks/mock-rel-1.json", searchInput, "", 0)
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query1),
 		gomock.Eq([]interface{}{}),
 	).Return(mockRows, nil)
-	mockRows2 := newMockRowsWithoutRBAC("./mocks/mock.json", searchInput2, "", 0)
 
-	relatedQuery := `SELECT "uid", "cluster", "data" FROM "search"."resources" WHERE ("uid" IN ('local-cluster/30c35f12-320a-417f-98d1-fbee28a4b2a6')) LIMIT 1000`
-	// Mock the database query
-	mockPool2.EXPECT().Query(gomock.Any(),
-		gomock.Eq(relatedQuery),
+	// Mock the SECOND database request.
+	query2 := `SELECT "uid", "cluster", "data" FROM "search"."resources" WHERE ("uid" IN ('local-cluster/30c35f12-320a-417f-98d1-fbee28a4b2a6')) LIMIT 1000`
+	mockRows2 := newMockRowsWithoutRBAC("./mocks/mock.json", searchInput, "", 0)
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query2),
 		gomock.Eq([]interface{}{}),
 	).Return(mockRows2, nil)
 
-	result := resolver.Related(context.Background()) // this should return a relatedResults object
+	// Execute the function - should return a relatedResults object
+	result := resolver.Related(context.Background())
 
+	// Verify returned items.
 	if !strings.EqualFold(result[0].Kind, strings.ToLower(mockRows2.mockData[0]["destkind"].(string))) {
 		t.Errorf("Kind value in mockdata does not match kind value of result")
 	}
-
-	// Verify returned items.
 	if len(result) != len(mockRows2.mockData) {
 		t.Errorf("Items() received incorrect number of items. Expected %d Got: %d", len(mockRows.mockData), len(result))
 	}
@@ -146,42 +155,39 @@ func Test_SearchResolver_RelatedKindsRelationships(t *testing.T) {
 
 func Test_SearchResolver_RelatedKindsRelationships_NegativeLimit(t *testing.T) {
 	config.Cfg.RelationLevel = 3
-	var resultList []*string
 
+	// Build a mock SearchResolver{} using uids as filter input.
 	uid1 := "local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd"
 	uid2 := "local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b"
-
+	resultList := []*string{&uid1, &uid2}
 	limit := -1
-	resultList = append(resultList, &uid1, &uid2)
-	relatedKind1 := "ConfigMap"
-	// take the uids from above as input
-	searchInput2 := &model.SearchInput{Limit: &limit, RelatedKinds: []*string{&relatedKind1}, Filters: []*model.SearchFilter{{Property: "uid", Values: resultList}}}
-	ud := rbac.UserData{}
-	resolver, mockPool2 := newMockSearchResolver(t, searchInput2, resultList, &ud, nil)
+	relatedKind := "ConfigMap"
+	searchInput := &model.SearchInput{Limit: &limit, RelatedKinds: []*string{&relatedKind}, Filters: []*model.SearchFilter{{Property: "uid", Values: resultList}}}
+	resolver, mockPool := newMockSearchResolver(t, searchInput, resultList, &rbac.UserData{}, nil)
 
-	relQuery := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (WITH RECURSIVE search_graph(level, sourceid, destid,  sourcekind, destkind, cluster) AS (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')) OR ("sourceid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) UNION (SELECT level+1 AS "level", "e"."sourceid", "e"."destid", "e"."sourcekind", "e"."destkind", "e"."cluster" FROM "search"."edges" AS "e" INNER JOIN "search_graph" AS "sg" ON (("sg"."destid" IN ("e"."sourceid", "e"."destid")) OR ("sg"."sourceid" IN ("e"."sourceid", "e"."destid"))) WHERE (("e"."destkind" NOT IN ('Node', 'Channel')) AND ("e"."sourcekind" NOT IN ('Node', 'Channel')) AND ("sg"."level" <= 3)))) SELECT DISTINCT "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search_graph") AS "search_graph") AS "combineIds" WHERE (("level" <= 3) AND ("uid" NOT IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) GROUP BY "uid", "kind") AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{}')) OR ((data->>'_hubClusterResource' = 'true') AND NULL))`)
-
-	mockRows := newMockRowsWithoutRBAC("./mocks/mock-rel-1.json", searchInput2, "", 0)
-	mockPool2.EXPECT().Query(gomock.Any(),
-		gomock.Eq(relQuery),
+	// Mock the FIRST database request.
+	query := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (WITH RECURSIVE search_graph(level, sourceid, destid,  sourcekind, destkind, cluster) AS (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')) OR ("sourceid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) UNION (SELECT level+1 AS "level", "e"."sourceid", "e"."destid", "e"."sourcekind", "e"."destkind", "e"."cluster" FROM "search"."edges" AS "e" INNER JOIN "search_graph" AS "sg" ON (("sg"."destid" IN ("e"."sourceid", "e"."destid")) OR ("sg"."sourceid" IN ("e"."sourceid", "e"."destid"))) WHERE (("e"."destkind" NOT IN ('Node', 'Channel')) AND ("e"."sourcekind" NOT IN ('Node', 'Channel')) AND ("sg"."level" <= 3)))) SELECT DISTINCT "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search_graph") AS "search_graph") AS "combineIds" WHERE (("level" <= 3) AND ("uid" NOT IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) GROUP BY "uid", "kind") AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{}')) OR ((data->>'_hubClusterResource' = 'true') AND NULL))`)
+	mockRows := newMockRowsWithoutRBAC("./mocks/mock-rel-1.json", searchInput, "", 0)
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query),
 		gomock.Eq([]interface{}{}),
 	).Return(mockRows, nil)
-	mockRows2 := newMockRowsWithoutRBAC("./mocks/mock.json", searchInput2, "", 0)
 
-	relatedQuery := `SELECT "uid", "cluster", "data" FROM "search"."resources" WHERE ("uid" IN ('local-cluster/30c35f12-320a-417f-98d1-fbee28a4b2a6'))`
-	// Mock the database query
-	mockPool2.EXPECT().Query(gomock.Any(),
-		gomock.Eq(relatedQuery),
+	// Mock the SECOND database request.
+	query2 := `SELECT "uid", "cluster", "data" FROM "search"."resources" WHERE ("uid" IN ('local-cluster/30c35f12-320a-417f-98d1-fbee28a4b2a6'))`
+	mockRows2 := newMockRowsWithoutRBAC("./mocks/mock.json", searchInput, "", 0)
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query2),
 		gomock.Eq([]interface{}{}),
 	).Return(mockRows2, nil)
 
-	result := resolver.Related(context.Background()) // this should return a relatedResults object
+	// Execute the function - should return a relatedResults object
+	result := resolver.Related(context.Background())
 
+	// Verify returned items.
 	if !strings.EqualFold(result[0].Kind, strings.ToLower(mockRows2.mockData[0]["destkind"].(string))) {
 		t.Errorf("Kind value in mockdata does not match kind value of result")
 	}
-
-	// Verify returned items.
 	if len(result) != len(mockRows2.mockData) {
 		t.Errorf("Items() received incorrect number of items. Expected %d Got: %d", len(mockRows.mockData), len(result))
 	}
@@ -189,42 +195,41 @@ func Test_SearchResolver_RelatedKindsRelationships_NegativeLimit(t *testing.T) {
 
 func Test_SearchResolver_Level1Related(t *testing.T) {
 	config.Cfg.RelationLevel = 0
-	var resultList []*string
+
+	// Build a mock SearchResolver{} using uids as filter input.
 	uid1 := "local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd"
 	uid2 := "local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b"
-
+	resultList := []*string{&uid1, &uid2}
 	limit := -1
-	resultList = append(resultList, &uid1, &uid2)
-	relatedKind1 := "ConfigMap"
-	// take the uids from above as input
-	searchInput2 := &model.SearchInput{Limit: &limit, RelatedKinds: []*string{&relatedKind1}, Filters: []*model.SearchFilter{{Property: "uid", Values: resultList}}}
+	relatedKind := "ConfigMap"
+	searchInput := &model.SearchInput{Limit: &limit, RelatedKinds: []*string{&relatedKind}, Filters: []*model.SearchFilter{{Property: "uid", Values: resultList}}}
 	csRes, nsRes, mc := newUserData()
 	ud := rbac.UserData{CsResources: csRes, NsResources: nsRes, ManagedClusters: mc}
-	resolver, mockPool2 := newMockSearchResolver(t, searchInput2, resultList, &ud, nil)
+	resolver, mockPool := newMockSearchResolver(t, searchInput, resultList, &ud, nil)
 
-	relQuery := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')) OR ("sourceid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')))) AS "search_graph") AS "combineIds" WHERE (("level" <= 1) AND ("uid" NOT IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) GROUP BY "uid", "kind") AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{"managed1","managed2"}')) OR ((data->>'_hubClusterResource' = 'true') AND (((COALESCE(data->>'namespace', '') = '') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'nodes')) OR ((COALESCE(data->>'apigroup', '') = 'storage.k8s.io') AND (data->>'kind_plural' = 'csinodes')))) OR (((data->>'namespace' = 'default') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'configmaps')) OR ((COALESCE(data->>'apigroup', '') = 'v4') AND (data->>'kind_plural' = 'services')))) OR ((data->>'namespace' = 'ocm') AND (((COALESCE(data->>'apigroup', '') = 'v1') AND (data->>'kind_plural' = 'pods')) OR ((COALESCE(data->>'apigroup', '') = 'v2') AND (data->>'kind_plural' = 'deployments'))))))))`)
-
-	mockRows := newMockRowsWithoutRBAC("./mocks/mock-rel-1.json", searchInput2, "", 0)
-	mockPool2.EXPECT().Query(gomock.Any(),
-		gomock.Eq(relQuery),
+	// Mock the FIRST database request.
+	query := strings.TrimSpace(`SELECT "related"."uid", "related"."kind", "related"."level" FROM (SELECT "uid", "kind", MIN("level") AS "level" FROM (SELECT "level", unnest(array[sourceid, destid, concat('cluster__',cluster)]) AS "uid", unnest(array[sourcekind, destkind, 'Cluster']) AS "kind" FROM (SELECT 1 AS "level", "sourceid", "destid", "sourcekind", "destkind", "cluster" FROM "search"."edges" AS "e" WHERE (("destid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')) OR ("sourceid" IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b')))) AS "search_graph") AS "combineIds" WHERE (("level" <= 1) AND ("uid" NOT IN ('local-cluster/e12c2ddd-4ac5-499d-b0e0-20242f508afd', 'local-cluster/13250bc4-865c-41db-a8f2-05bec0bd042b'))) GROUP BY "uid", "kind") AS "related" INNER JOIN "search"."resources" ON ("related"."uid" = "resources".uid) WHERE (("cluster" = ANY ('{"managed1","managed2"}')) OR ((data->>'_hubClusterResource' = 'true') AND (((COALESCE(data->>'namespace', '') = '') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'nodes')) OR ((COALESCE(data->>'apigroup', '') = 'storage.k8s.io') AND (data->>'kind_plural' = 'csinodes')))) OR (((data->>'namespace' = 'default') AND (((COALESCE(data->>'apigroup', '') = '') AND (data->>'kind_plural' = 'configmaps')) OR ((COALESCE(data->>'apigroup', '') = 'v4') AND (data->>'kind_plural' = 'services')))) OR ((data->>'namespace' = 'ocm') AND (((COALESCE(data->>'apigroup', '') = 'v1') AND (data->>'kind_plural' = 'pods')) OR ((COALESCE(data->>'apigroup', '') = 'v2') AND (data->>'kind_plural' = 'deployments'))))))))`)
+	mockRows := newMockRowsWithoutRBAC("./mocks/mock-rel-1.json", searchInput, "", 0)
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query),
 		gomock.Eq([]interface{}{}),
 	).Return(mockRows, nil)
-	mockRows2 := newMockRowsWithoutRBAC("./mocks/mock.json", searchInput2, "", 0)
 
-	relatedQuery := `SELECT "uid", "cluster", "data" FROM "search"."resources" WHERE ("uid" IN ('local-cluster/30c35f12-320a-417f-98d1-fbee28a4b2a6'))`
-	// Mock the database query
-	mockPool2.EXPECT().Query(gomock.Any(),
-		gomock.Eq(relatedQuery),
+	// Mock the SECOND database request.
+	query2 := `SELECT "uid", "cluster", "data" FROM "search"."resources" WHERE ("uid" IN ('local-cluster/30c35f12-320a-417f-98d1-fbee28a4b2a6'))`
+	mockRows2 := newMockRowsWithoutRBAC("./mocks/mock.json", searchInput, "", 0)
+	mockPool.EXPECT().Query(gomock.Any(),
+		gomock.Eq(query2),
 		gomock.Eq([]interface{}{}),
 	).Return(mockRows2, nil)
 
-	result := resolver.Related(context.Background()) // this should return a relatedResults object
+	// Execute the function - should return a relatedResults object
+	result := resolver.Related(context.Background())
 
+	// Verify returned items.
 	if !strings.EqualFold(result[0].Kind, strings.ToLower(mockRows2.mockData[0]["destkind"].(string))) {
 		t.Errorf("Kind value in mockdata does not match kind value of result")
 	}
-
-	// Verify returned items.
 	if len(result) != len(mockRows2.mockData) {
 		t.Errorf("Items() received incorrect number of items. Expected %d Got: %d", len(mockRows.mockData), len(result))
 	}

--- a/pkg/resolver/search.go
+++ b/pkg/resolver/search.go
@@ -100,7 +100,7 @@ func (s *SearchResult) Related(ctx context.Context) []SearchRelatedResult {
 	if len(s.uids) > 0 {
 		start = time.Now()
 		numUIDs = len(s.uids)
-		r = s.getRelations(ctx)
+		r = s.getRelationResolvers(ctx)
 	} else {
 		klog.Warning("No uids selected for query:Related()")
 	}


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  stolostron/backlog#26115

### Description of changes
- Fixes related items returning null when the relatedKinds filter is not included in the query.
- Fixes the case of the `kind` property on related items to match the search results.

Tested with this script:
```bash
# configure
oc create route passthrough search-api --service=search-search-api -n open-cluster-management
export URL="https://$(oc get route search-api -n open-cluster-management | awk 'NR==2' |awk '{print $2;}')/searchapi/graphql"
export TOKEN=$(oc whoami -t)

# Request all related items.
curl --insecure --location \
--request POST $URL \
--header "Authorization: Bearer $TOKEN" --header 'Content-Type: application/json' \
--data-raw '{"query":"query q($input: [SearchInput]) { search(input: $input) { related { kind count items } } }","variables":{"input":[{"keywords":[],"filters":[{"property":"label","values":["app=search"]}], "limit":100}]}}' | jq

# Request only related secrets
curl --insecure --location \
--request POST $URL \
--header "Authorization: Bearer $TOKEN" --header 'Content-Type: application/json' \
--data-raw '{"query":"query q($input: [SearchInput]) { search(input: $input) { related { kind count items } } }","variables":{"input":[{"relatedKinds":["Secret"], "keywords":[],"filters":[{"property":"label","values":["app=search"]}], "limit":100}]}}' | jq
```