### PR TITLE
Parallelize API calls to build cluster-scoped access (SSAR)

### DIFF
--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-var impersonationConfigCreationerror = "Error creating clientset with impersonation config"
+const impersonationConfigCreationerror = "Error creating clientset with impersonation config"
 
 // Contains data about the resources the user is allowed to access.
 type UserDataCache struct {

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -194,7 +194,7 @@ func (user *UserDataCache) isValid() bool {
 // Equivalent to: oc auth can-i list <resource> --as=<user>
 func (user *UserDataCache) getClusterScopedResources(cache *Cache, ctx context.Context,
 	clientToken string) (*UserDataCache, error) {
-	defer metric.SlowLog("UserDataCache::getClusterScopedResources", 100*time.Millisecond)()
+	defer metric.SlowLog("UserDataCache::getClusterScopedResources", 200*time.Millisecond)()
 
 	user.csrErr = nil
 	user.csrLock.Lock()

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -194,7 +194,7 @@ func (user *UserDataCache) isValid() bool {
 // Equivalent to: oc auth can-i list <resource> --as=<user>
 func (user *UserDataCache) getClusterScopedResources(cache *Cache, ctx context.Context,
 	clientToken string) (*UserDataCache, error) {
-	defer metric.SlowLog("UserDataCache::getClusterScopedResources", 200*time.Millisecond)()
+	defer metric.SlowLog("UserDataCache::getClusterScopedResources", 150*time.Millisecond)()
 
 	user.csrErr = nil
 	user.csrLock.Lock()


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  https://github.com/stolostron/backlog/issues/22013

### Description of changes
- Parallelize API calls to build cluster-scoped
- **Reduces function time from 2.5s to ~125ms.**
