### PR TITLE
Another refactor to simplify cache and keep consistency

### DIFF
--- a/pkg/rbac/cache.go
+++ b/pkg/rbac/cache.go
@@ -28,7 +28,7 @@ type Cache struct {
 }
 
 // Common fields to manage a cached data field.
-type cacheFieldMgmt struct {
+type cacheMetadata struct {
 	err       error      // Error while retrieving the data from external API.
 	lock      sync.Mutex // Locks the data field while requesting the latest data.
 	updatedAt time.Time  // Time when the data field was last updated.

--- a/pkg/rbac/sharedData.go
+++ b/pkg/rbac/sharedData.go
@@ -27,11 +27,11 @@ type SharedData struct {
 	namespaces       []string
 	propTypes        map[string]string
 
-	// Added fields to manage the state of the cached data.
-	csrCache    cacheFieldMgmt
-	dcCache     cacheFieldMgmt
-	mcCache     cacheFieldMgmt
-	nsCache     cacheFieldMgmt
+	// Metadata to manage the state of the cached data.
+	csrCache    cacheMetadata
+	dcCache     cacheMetadata
+	mcCache     cacheMetadata
+	nsCache     cacheMetadata
 	propTypeErr error // Capture errors retrieving property types
 
 	// Clients to external APIs to be replaced with a mock by unit tests.

--- a/pkg/rbac/sharedData.go
+++ b/pkg/rbac/sharedData.go
@@ -27,15 +27,14 @@ type SharedData struct {
 	namespaces       []string
 	propTypes        map[string]string
 
-	// These are internal objects to track the state of the cache.
+	// Added fields to manage the state of the cached data.
 	csrCache    cacheFieldMgmt
 	dcCache     cacheFieldMgmt
 	mcCache     cacheFieldMgmt
 	nsCache     cacheFieldMgmt
 	propTypeErr error // Capture errors retrieving property types
 
-	// Clients to external APIs.
-	// Defining these here allow the tests to replace with a mock client.
+	// Clients to external APIs to be replaced with a mock by unit tests.
 	corev1Client  corev1.CoreV1Interface
 	dynamicClient dynamic.Interface
 	pool          pgxpoolmock.PgxPool // Database client

--- a/pkg/rbac/sharedData_test.go
+++ b/pkg/rbac/sharedData_test.go
@@ -124,8 +124,8 @@ func Test_getResouces_usingCache(t *testing.T) {
 	mock_cache.shared = SharedData{
 		namespaces:      namespaces,
 		managedClusters: manClusters,
-		mcCache:         cacheFieldMgmt{updatedAt: time.Now()},
-		csrCache:        cacheFieldMgmt{updatedAt: time.Now()},
+		mcCache:         cacheMetadata{updatedAt: time.Now()},
+		csrCache:        cacheMetadata{updatedAt: time.Now()},
 		csResourcesMap:  csRes,
 		propTypes:       propTypesMock,
 		corev1Client:    mock_cache.shared.corev1Client,
@@ -179,9 +179,9 @@ func Test_getResources_expiredCache(t *testing.T) {
 	mock_cache.shared = SharedData{
 		namespaces:      namespaces,
 		managedClusters: manClusters,
-		nsCache:         cacheFieldMgmt{updatedAt: last_cache_time},
-		mcCache:         cacheFieldMgmt{updatedAt: last_cache_time},
-		csrCache:        cacheFieldMgmt{updatedAt: last_cache_time},
+		nsCache:         cacheMetadata{updatedAt: last_cache_time},
+		mcCache:         cacheMetadata{updatedAt: last_cache_time},
+		csrCache:        cacheMetadata{updatedAt: last_cache_time},
 		csResourcesMap:  csRes,
 		corev1Client:    mock_cache.shared.corev1Client,
 		dynamicClient:   mock_cache.shared.dynamicClient,
@@ -243,9 +243,9 @@ func Test_GetandSetDisabledClusters(t *testing.T) {
 	//user's managedclusters
 
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: dClusters},
-		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
+		csrCache:      cacheMetadata{updatedAt: time.Now()},
+		nsrCache:      cacheMetadata{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	res, _ := mock_cache.GetDisabledClusters(context.WithValue(context.Background(),
@@ -276,9 +276,9 @@ func Test_getDisabledClusters_UserNotFound(t *testing.T) {
 	manClusters := map[string]struct{}{}
 	manClusters["disabled1"] = struct{}{}
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
+		csrCache:      cacheMetadata{updatedAt: time.Now()},
+		nsrCache:      cacheMetadata{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil
@@ -304,9 +304,9 @@ func Test_getDisabledClustersValid(t *testing.T) {
 	manClusters := map[string]struct{}{"disabled1": {}}
 
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
+		csrCache:      cacheMetadata{updatedAt: time.Now()},
+		nsrCache:      cacheMetadata{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil
@@ -332,9 +332,9 @@ func Test_getDisabledClustersValid_User_NoAccess(t *testing.T) {
 
 	//user only has access to "managed1" cluster, but not "disabled1" cluster
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
+		csrCache:      cacheMetadata{updatedAt: time.Now()},
+		nsrCache:      cacheMetadata{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil
@@ -359,9 +359,9 @@ func Test_getDisabledClustersCacheInValid_RunQuery(t *testing.T) {
 	//user's managedclusters
 	manClusters := map[string]struct{}{"disabled1": {}}
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
+		csrCache:      cacheMetadata{updatedAt: time.Now()},
+		nsrCache:      cacheMetadata{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil
@@ -401,9 +401,9 @@ func Test_getDisabledClustersCacheInValid_RunQueryError(t *testing.T) {
 
 	//user has no access to disabled clusters
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
+		csrCache:      cacheMetadata{updatedAt: time.Now()},
+		nsrCache:      cacheMetadata{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil

--- a/pkg/rbac/sharedData_test.go
+++ b/pkg/rbac/sharedData_test.go
@@ -243,7 +243,9 @@ func Test_GetandSetDisabledClusters(t *testing.T) {
 	//user's managedclusters
 
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: dClusters},
-		csrUpdatedAt: time.Now(), nsrUpdatedAt: time.Now(), clustersUpdatedAt: time.Now()}
+		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	res, _ := mock_cache.GetDisabledClusters(context.WithValue(context.Background(),
@@ -274,7 +276,9 @@ func Test_getDisabledClusters_UserNotFound(t *testing.T) {
 	manClusters := map[string]struct{}{}
 	manClusters["disabled1"] = struct{}{}
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrUpdatedAt: time.Now(), nsrUpdatedAt: time.Now(), clustersUpdatedAt: time.Now()}
+		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil
@@ -300,7 +304,9 @@ func Test_getDisabledClustersValid(t *testing.T) {
 	manClusters := map[string]struct{}{"disabled1": {}}
 
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrUpdatedAt: time.Now(), nsrUpdatedAt: time.Now(), clustersUpdatedAt: time.Now()}
+		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil
@@ -326,7 +332,9 @@ func Test_getDisabledClustersValid_User_NoAccess(t *testing.T) {
 
 	//user only has access to "managed1" cluster, but not "disabled1" cluster
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrUpdatedAt: time.Now(), nsrUpdatedAt: time.Now(), clustersUpdatedAt: time.Now()}
+		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil
@@ -351,7 +359,9 @@ func Test_getDisabledClustersCacheInValid_RunQuery(t *testing.T) {
 	//user's managedclusters
 	manClusters := map[string]struct{}{"disabled1": {}}
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrUpdatedAt: time.Now(), nsrUpdatedAt: time.Now(), clustersUpdatedAt: time.Now()}
+		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil
@@ -391,7 +401,9 @@ func Test_getDisabledClustersCacheInValid_RunQueryError(t *testing.T) {
 
 	//user has no access to disabled clusters
 	userdataCache := UserDataCache{UserData: UserData{ManagedClusters: manClusters},
-		csrUpdatedAt: time.Now(), nsrUpdatedAt: time.Now(), clustersUpdatedAt: time.Now()}
+		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()}}
 	setupUserDataCache(&mock_cache, &userdataCache)
 
 	mock_cache.shared.dcCache.err = nil

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -25,10 +25,10 @@ const impersonationConfigCreationerror = "Error creating clientset with imperson
 type UserDataCache struct {
 	UserData
 
-	// Added fields to manage the state of the cached data.
-	clustersCache cacheFieldMgmt // NOTE: clustersCache.lock not used because we use the nsrCache.lock
-	csrCache      cacheFieldMgmt
-	nsrCache      cacheFieldMgmt
+	// Metadata to manage the state of the cached data.
+	clustersCache cacheMetadata // NOTE: clustersCache.lock not used because we use the nsrCache.lock
+	csrCache      cacheMetadata
+	nsrCache      cacheMetadata
 
 	// Client to external API to be replaced with a mock by unit tests.
 	authzClient v1.AuthorizationV1Interface

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -25,13 +25,12 @@ const impersonationConfigCreationerror = "Error creating clientset with imperson
 type UserDataCache struct {
 	UserData
 
-	// Added fields to manage the cache.
+	// Added fields to manage the state of the cached data.
 	clustersCache cacheFieldMgmt // NOTE: clustersCache.lock not used because we use the nsrCache.lock
 	csrCache      cacheFieldMgmt
 	nsrCache      cacheFieldMgmt
 
-	// Client to external API.
-	// Defining these here allow the tests to replace with a mock client.
+	// Client to external API to be replaced with a mock by unit tests.
 	authzClient v1.AuthorizationV1Interface
 }
 

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -25,13 +25,13 @@ const impersonationConfigCreationerror = "Error creating clientset with imperson
 type UserDataCache struct {
 	UserData
 
-	// Internal fields to manage the cache.
-
-	// NOTE: clustersCache.lock not used because we use the nsrCache.lock
-	clustersCache cacheFieldMgmt
+	// Added fields to manage the cache.
+	clustersCache cacheFieldMgmt // NOTE: clustersCache.lock not used because we use the nsrCache.lock
 	csrCache      cacheFieldMgmt
 	nsrCache      cacheFieldMgmt
 
+	// Client to external API.
+	// Defining these here allow the tests to replace with a mock client.
 	authzClient v1.AuthorizationV1Interface
 }
 

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -26,18 +26,11 @@ type UserDataCache struct {
 	UserData
 
 	// Internal fields to manage the cache.
-	clustersErr error // Error while updating clusters data.
-	// NOTE: not implemented because we use the nsrLock
-	// clustersLock      sync.Mutex // Locks when clusters data is being updated.
-	clustersUpdatedAt time.Time // Time clusters was last updated.
 
-	csrErr       error      // Error while updating cluster-scoped resources data.
-	csrLock      sync.Mutex // Locks when cluster-scoped resources data is being updated.
-	csrUpdatedAt time.Time  // Time cluster-scoped resources was last updated.
-
-	nsrErr       error      // Error while updating namespaced resources data.
-	nsrLock      sync.Mutex // Locks when namespaced resources data is being updated.
-	nsrUpdatedAt time.Time  // Time namespaced resources was last updated.
+	// NOTE: clustersCache.lock not used because we use the nsrCache.lock
+	clustersCache cacheFieldMgmt
+	csrCache      cacheFieldMgmt
+	nsrCache      cacheFieldMgmt
 
 	authzClient v1.AuthorizationV1Interface
 }
@@ -143,19 +136,19 @@ func (user *UserDataCache) userHasAllAccess(cache *Cache, ctx context.Context, c
 	}
 	//If we have a new set of authorized list for the user reset the previous one
 	if user.userAuthorizedListSSAR(ctx, impersClientset, "*", "*") {
-		user.csrLock.Lock()
-		defer user.csrLock.Unlock()
+		user.csrCache.lock.Lock()
+		defer user.csrCache.lock.Unlock()
 		user.CsResources = []Resource{{Apigroup: "*", Kind: "*"}}
-		user.csrUpdatedAt = time.Now()
+		user.csrCache.updatedAt = time.Now()
 
-		user.nsrLock.Lock()
-		defer user.nsrLock.Unlock()
+		user.nsrCache.lock.Lock()
+		defer user.nsrCache.lock.Unlock()
 		user.NsResources = map[string][]Resource{"*": {{Apigroup: "*", Kind: "*"}}}
-		user.nsrUpdatedAt = time.Now()
+		user.nsrCache.updatedAt = time.Now()
 
 		user.ManagedClusters = cache.shared.managedClusters
-		user.clustersUpdatedAt = time.Now()
-		user.csrErr, user.nsrErr, user.clustersErr = nil, nil, nil
+		user.clustersCache.updatedAt = time.Now()
+		user.csrCache.err, user.nsrCache.err, user.clustersCache.err = nil, nil, nil
 		return true, nil
 	}
 	return false, nil
@@ -182,9 +175,9 @@ func (cache *Cache) GetUserData(ctx context.Context) (*UserData, error) {
 /* Cache is Valid if the csrUpdatedAt and nsrUpdatedAt times are before the
 Cache expiry time */
 func (user *UserDataCache) isValid() bool {
-	if (time.Now().Before(user.csrUpdatedAt.Add(time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond))) &&
-		(time.Now().Before(user.nsrUpdatedAt.Add(time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond))) &&
-		(time.Now().Before(user.clustersUpdatedAt.Add(time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond))) {
+	if (time.Now().Before(user.csrCache.updatedAt.Add(time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond))) &&
+		(time.Now().Before(user.nsrCache.updatedAt.Add(time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond))) &&
+		(time.Now().Before(user.clustersCache.updatedAt.Add(time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond))) {
 		return true
 	}
 	return false
@@ -196,21 +189,21 @@ func (user *UserDataCache) getClusterScopedResources(cache *Cache, ctx context.C
 	clientToken string) (*UserDataCache, error) {
 	defer metric.SlowLog("UserDataCache::getClusterScopedResources", 150*time.Millisecond)()
 
-	user.csrErr = nil
-	user.csrLock.Lock()
-	defer user.csrLock.Unlock()
+	user.csrCache.err = nil
+	user.csrCache.lock.Lock()
+	defer user.csrCache.lock.Unlock()
 
 	// Not present in cache, find all cluster scoped resources
 	clusterScopedResources := cache.shared.csResourcesMap
 	if len(clusterScopedResources) == 0 {
-		klog.Warning("Cluster scoped resources from shared cache empty.", user.csrErr)
-		return user, user.csrErr
+		klog.Warning("Cluster scoped resources from shared cache empty.", user.csrCache.err)
+		return user, user.csrCache.err
 	}
 	impersClientset, err := user.getImpersonationClientSet(clientToken, cache)
 	if err != nil {
-		user.csrErr = err
+		user.csrCache.err = err
 		klog.Warning(impersonationConfigCreationerror, err.Error())
-		return user, user.csrErr
+		return user, user.csrCache.err
 	}
 	// If we have a new set of authorized list for the user reset the previous one
 	user.CsResources = nil
@@ -236,8 +229,8 @@ func (user *UserDataCache) getClusterScopedResources(cache *Cache, ctx context.C
 	uid, userInfo := cache.GetUserUID(ctx)
 	klog.V(7).Infof("User %s with uid: %s has access to these cluster scoped res: %+v \n", userInfo.Username, uid,
 		user.CsResources)
-	user.csrUpdatedAt = time.Now()
-	return user, user.csrErr
+	user.csrCache.updatedAt = time.Now()
+	return user, user.csrCache.err
 }
 
 func (user *UserDataCache) userAuthorizedListSSAR(ctx context.Context, authzClient v1.AuthorizationV1Interface,
@@ -354,19 +347,19 @@ func (user *UserDataCache) getNamespacedResources(cache *Cache, ctx context.Cont
 	clientToken string) (*UserDataCache, error) {
 	defer metric.SlowLog("UserDataCache::getNamespacedResources", 250*time.Millisecond)()
 	// check if we already have user's namespaced resources in userData cache and check if time is expired
-	user.nsrLock.Lock()
-	defer user.nsrLock.Unlock()
+	user.nsrCache.lock.Lock()
+	defer user.nsrCache.lock.Unlock()
 
 	// clear cache
-	user.csrErr = nil
+	user.csrCache.err = nil
 	user.NsResources = nil
-	user.clustersErr = nil
+	user.clustersCache.err = nil
 	user.ManagedClusters = nil
 
 	// get all namespaces from shared cache:
 	klog.V(5).Info("Getting namespaces from shared cache.")
-	user.csrLock.Lock()
-	defer user.csrLock.Unlock()
+	user.csrCache.lock.Lock()
+	defer user.csrCache.lock.Unlock()
 	allNamespaces := cache.shared.namespaces // TO-DO-Separate-PR: Should not access data from shared cache directly.
 	if len(allNamespaces) == 0 {
 		klog.Warning("All namespaces array from shared cache is empty.", cache.shared.nsCache.err)
@@ -393,10 +386,10 @@ func (user *UserDataCache) getNamespacedResources(cache *Cache, ctx context.Cont
 	klog.V(7).Infof("User %s with uid: %s has access to these ManagedClusters: %+v \n", userInfo.Username, uid,
 		user.ManagedClusters)
 
-	user.nsrUpdatedAt = time.Now()
-	user.clustersUpdatedAt = time.Now()
+	user.nsrCache.updatedAt = time.Now()
+	user.clustersCache.updatedAt = time.Now()
 
-	return user, user.nsrErr
+	return user, user.nsrCache.err
 }
 
 // SSRR has resources that are clusterscoped too

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -135,9 +135,9 @@ func Test_getNamespaces_usingCache(t *testing.T) {
 	mock_cache.users["unique-user-id"] = &UserDataCache{
 		UserData: UserData{ManagedClusters: managedclusters,
 			NsResources: nsresources},
-		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()},
+		csrCache:      cacheMetadata{updatedAt: time.Now()},
+		nsrCache:      cacheMetadata{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()},
 	}
 
 	rulesCheck := &authz.SelfSubjectRulesReview{
@@ -201,7 +201,7 @@ func Test_getNamespaces_expiredCache(t *testing.T) {
 	last_cache_time := time.Now().Add(time.Duration(-5) * time.Minute)
 	mock_cache.users["unique-user-id"] = &UserDataCache{
 		UserData: UserData{NsResources: nsresources},
-		nsrCache: cacheFieldMgmt{updatedAt: last_cache_time},
+		nsrCache: cacheMetadata{updatedAt: last_cache_time},
 	}
 	rulesCheck := &authz.SelfSubjectRulesReview{
 		Spec: authz.SelfSubjectRulesReviewSpec{
@@ -264,10 +264,10 @@ func Test_clusterScoped_usingCache(t *testing.T) {
 		UserData: UserData{
 			CsResources:     []Resource{{Apigroup: "storage.k8s.io", Kind: "nodes"}},
 			ManagedClusters: map[string]struct{}{"some-namespace": {}}},
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()},
 		// Using current time , GetUserData should have the same values as cache
-		csrCache: cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache: cacheFieldMgmt{updatedAt: time.Now()},
+		csrCache: cacheMetadata{updatedAt: time.Now()},
+		nsrCache: cacheMetadata{updatedAt: time.Now()},
 	}
 	ctx := context.WithValue(context.Background(), ContextAuthTokenKey, "123456")
 
@@ -338,7 +338,7 @@ func Test_clusterScoped_expiredCache(t *testing.T) {
 		UserData: UserData{
 			CsResources: []Resource{{Apigroup: "k8s.io", Kind: "csinodes"}},
 		},
-		csrCache:    cacheFieldMgmt{updatedAt: last_cache_time},
+		csrCache:    cacheMetadata{updatedAt: last_cache_time},
 		authzClient: fs.AuthorizationV1(),
 	}
 
@@ -447,10 +447,10 @@ func Test_managedClusters_usingCache(t *testing.T) {
 			CsResources:     []Resource{{Apigroup: "storage.k8s.io", Kind: "nodes"}},
 			ManagedClusters: map[string]struct{}{"some-managed-cluster": {}, "some-other-managed-cluster": {}},
 		},
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()},
 		// Using current time , GetUserData should have the same values as cache
-		csrCache: cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache: cacheFieldMgmt{updatedAt: time.Now()},
+		csrCache: cacheMetadata{updatedAt: time.Now()},
+		nsrCache: cacheMetadata{updatedAt: time.Now()},
 	}
 	ctx := context.WithValue(context.Background(), ContextAuthTokenKey, "123456")
 
@@ -538,7 +538,7 @@ func Test_managedCluster_expiredCache(t *testing.T) {
 	last_cache_time := time.Now().Add(time.Duration(-5) * time.Minute)
 	mock_cache.users["unique-user-id"] = &UserDataCache{
 		UserData:      UserData{ManagedClusters: pastManClusters},
-		clustersCache: cacheFieldMgmt{updatedAt: last_cache_time},
+		clustersCache: cacheMetadata{updatedAt: last_cache_time},
 		authzClient:   fs.AuthorizationV1(),
 	}
 
@@ -573,7 +573,7 @@ func Test_managedCluster_GetUserData(t *testing.T) {
 	last_cache_time := time.Now().Add(time.Duration(-5) * time.Minute)
 	mock_cache.users["unique-user-id"] = &UserDataCache{
 		UserData:      UserData{ManagedClusters: managedClusters, CsResources: csRes, NsResources: nsRes},
-		clustersCache: cacheFieldMgmt{updatedAt: last_cache_time},
+		clustersCache: cacheMetadata{updatedAt: last_cache_time},
 	}
 	csResResult := mock_cache.users["unique-user-id"].GetCsResources()
 	if len(csResResult) != 2 {
@@ -601,9 +601,9 @@ func Test_getUserData(t *testing.T) {
 			NsResources:     map[string][]Resource{"ns1": {{Apigroup: "", Kind: "pods"}}},
 		},
 		// Using current time , GetUserData should have the same values as cache
-		clustersCache: cacheFieldMgmt{updatedAt: time.Now()},
-		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
-		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheMetadata{updatedAt: time.Now()},
+		csrCache:      cacheMetadata{updatedAt: time.Now()},
+		nsrCache:      cacheMetadata{updatedAt: time.Now()},
 	}
 	ctx := context.WithValue(context.Background(), ContextAuthTokenKey, "123456")
 
@@ -648,7 +648,7 @@ func Test_getImpersonationClientSet(t *testing.T) {
 
 	udc := &UserDataCache{
 		UserData: UserData{},
-		nsrCache: cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache: cacheMetadata{updatedAt: time.Now()},
 	}
 	_, err := udc.getImpersonationClientSet("123456", mock_cache)
 	// Ensure that there is no error
@@ -761,7 +761,7 @@ func Test_updateUserManagedClusterList(t *testing.T) {
 
 	udc := &UserDataCache{
 		UserData: UserData{ManagedClusters: make(map[string]struct{})},
-		nsrCache: cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache: cacheMetadata{updatedAt: time.Now()},
 	}
 	// All namespaces list
 	namespaces := map[string]struct{}{"some-namespace": {}, "some-nonmatching-namespace": {}, "invalid-namespace": {}}

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -135,9 +135,9 @@ func Test_getNamespaces_usingCache(t *testing.T) {
 	mock_cache.users["unique-user-id"] = &UserDataCache{
 		UserData: UserData{ManagedClusters: managedclusters,
 			NsResources: nsresources},
-		csrUpdatedAt:      time.Now(),
-		nsrUpdatedAt:      time.Now(),
-		clustersUpdatedAt: time.Now(),
+		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()},
 	}
 
 	rulesCheck := &authz.SelfSubjectRulesReview{
@@ -200,8 +200,8 @@ func Test_getNamespaces_expiredCache(t *testing.T) {
 
 	last_cache_time := time.Now().Add(time.Duration(-5) * time.Minute)
 	mock_cache.users["unique-user-id"] = &UserDataCache{
-		UserData:     UserData{NsResources: nsresources},
-		nsrUpdatedAt: last_cache_time,
+		UserData: UserData{NsResources: nsresources},
+		nsrCache: cacheFieldMgmt{updatedAt: last_cache_time},
 	}
 	rulesCheck := &authz.SelfSubjectRulesReview{
 		Spec: authz.SelfSubjectRulesReviewSpec{
@@ -247,7 +247,7 @@ func Test_getNamespaces_expiredCache(t *testing.T) {
 	}
 
 	//  Verify that cache was updated by checking the timestamp
-	if !mock_cache.users["unique-user-id"].nsrUpdatedAt.After(last_cache_time) {
+	if !mock_cache.users["unique-user-id"].nsrCache.updatedAt.After(last_cache_time) {
 		t.Error("Expected the cache.users.updatedAt to have a later timestamp")
 	}
 }
@@ -264,10 +264,10 @@ func Test_clusterScoped_usingCache(t *testing.T) {
 		UserData: UserData{
 			CsResources:     []Resource{{Apigroup: "storage.k8s.io", Kind: "nodes"}},
 			ManagedClusters: map[string]struct{}{"some-namespace": {}}},
-		clustersUpdatedAt: time.Now(),
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()},
 		// Using current time , GetUserData should have the same values as cache
-		csrUpdatedAt: time.Now(),
-		nsrUpdatedAt: time.Now(),
+		csrCache: cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache: cacheFieldMgmt{updatedAt: time.Now()},
 	}
 	ctx := context.WithValue(context.Background(), ContextAuthTokenKey, "123456")
 
@@ -338,8 +338,8 @@ func Test_clusterScoped_expiredCache(t *testing.T) {
 		UserData: UserData{
 			CsResources: []Resource{{Apigroup: "k8s.io", Kind: "csinodes"}},
 		},
-		csrUpdatedAt: last_cache_time,
-		authzClient:  fs.AuthorizationV1(),
+		csrCache:    cacheFieldMgmt{updatedAt: last_cache_time},
+		authzClient: fs.AuthorizationV1(),
 	}
 
 	ctx := context.WithValue(context.Background(), ContextAuthTokenKey, "123456")
@@ -354,7 +354,7 @@ func Test_clusterScoped_expiredCache(t *testing.T) {
 	}
 
 	//  Verify that cache was updated by checking the timestamp
-	if !mock_cache.users["unique-user-id"].csrUpdatedAt.After(last_cache_time) {
+	if !mock_cache.users["unique-user-id"].csrCache.updatedAt.After(last_cache_time) {
 		t.Error("Expected the cache.users.updatedAt to have a later timestamp")
 	}
 
@@ -447,10 +447,10 @@ func Test_managedClusters_usingCache(t *testing.T) {
 			CsResources:     []Resource{{Apigroup: "storage.k8s.io", Kind: "nodes"}},
 			ManagedClusters: map[string]struct{}{"some-managed-cluster": {}, "some-other-managed-cluster": {}},
 		},
-		clustersUpdatedAt: time.Now(),
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()},
 		// Using current time , GetUserData should have the same values as cache
-		csrUpdatedAt: time.Now(),
-		nsrUpdatedAt: time.Now(),
+		csrCache: cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache: cacheFieldMgmt{updatedAt: time.Now()},
 	}
 	ctx := context.WithValue(context.Background(), ContextAuthTokenKey, "123456")
 
@@ -537,9 +537,9 @@ func Test_managedCluster_expiredCache(t *testing.T) {
 
 	last_cache_time := time.Now().Add(time.Duration(-5) * time.Minute)
 	mock_cache.users["unique-user-id"] = &UserDataCache{
-		UserData:          UserData{ManagedClusters: pastManClusters},
-		clustersUpdatedAt: last_cache_time,
-		authzClient:       fs.AuthorizationV1(),
+		UserData:      UserData{ManagedClusters: pastManClusters},
+		clustersCache: cacheFieldMgmt{updatedAt: last_cache_time},
+		authzClient:   fs.AuthorizationV1(),
 	}
 
 	ctx := context.WithValue(context.Background(), ContextAuthTokenKey, "123456")
@@ -553,7 +553,7 @@ func Test_managedCluster_expiredCache(t *testing.T) {
 	}
 
 	//  Verify that cache was updated by checking the timestamp
-	if !mock_cache.users["unique-user-id"].clustersUpdatedAt.After(last_cache_time) {
+	if !mock_cache.users["unique-user-id"].clustersCache.updatedAt.After(last_cache_time) {
 		t.Error("Expected the cache.users.updatedAt to have a later timestamp")
 	}
 
@@ -572,8 +572,8 @@ func Test_managedCluster_GetUserData(t *testing.T) {
 
 	last_cache_time := time.Now().Add(time.Duration(-5) * time.Minute)
 	mock_cache.users["unique-user-id"] = &UserDataCache{
-		UserData:          UserData{ManagedClusters: managedClusters, CsResources: csRes, NsResources: nsRes},
-		clustersUpdatedAt: last_cache_time,
+		UserData:      UserData{ManagedClusters: managedClusters, CsResources: csRes, NsResources: nsRes},
+		clustersCache: cacheFieldMgmt{updatedAt: last_cache_time},
 	}
 	csResResult := mock_cache.users["unique-user-id"].GetCsResources()
 	if len(csResResult) != 2 {
@@ -601,9 +601,9 @@ func Test_getUserData(t *testing.T) {
 			NsResources:     map[string][]Resource{"ns1": {{Apigroup: "", Kind: "pods"}}},
 		},
 		// Using current time , GetUserData should have the same values as cache
-		clustersUpdatedAt: time.Now(),
-		csrUpdatedAt:      time.Now(),
-		nsrUpdatedAt:      time.Now(),
+		clustersCache: cacheFieldMgmt{updatedAt: time.Now()},
+		csrCache:      cacheFieldMgmt{updatedAt: time.Now()},
+		nsrCache:      cacheFieldMgmt{updatedAt: time.Now()},
 	}
 	ctx := context.WithValue(context.Background(), ContextAuthTokenKey, "123456")
 
@@ -647,8 +647,8 @@ func Test_getImpersonationClientSet(t *testing.T) {
 	mock_cache = setupToken(mock_cache)
 
 	udc := &UserDataCache{
-		UserData:     UserData{},
-		nsrUpdatedAt: time.Now(),
+		UserData: UserData{},
+		nsrCache: cacheFieldMgmt{updatedAt: time.Now()},
 	}
 	_, err := udc.getImpersonationClientSet("123456", mock_cache)
 	// Ensure that there is no error
@@ -760,8 +760,8 @@ func Test_updateUserManagedClusterList(t *testing.T) {
 	mock_cache = setupToken(mock_cache)
 
 	udc := &UserDataCache{
-		UserData:     UserData{ManagedClusters: make(map[string]struct{})},
-		nsrUpdatedAt: time.Now(),
+		UserData: UserData{ManagedClusters: make(map[string]struct{})},
+		nsrCache: cacheFieldMgmt{updatedAt: time.Now()},
 	}
 	// All namespaces list
 	namespaces := map[string]struct{}{"some-namespace": {}, "some-nonmatching-namespace": {}, "invalid-namespace": {}}


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  N/A

### Description of changes
- Continuation of 
  - #114 and 
  - #115 
- Simplify cache and manage data fields consistently using `cacheFieldMgmt{}`
