### PR TITLE
Refactor: Consolidate kube clients for simplicity

### DIFF
--- a/pkg/rbac/cache.go
+++ b/pkg/rbac/cache.go
@@ -33,7 +33,6 @@ var cacheInst = Cache{
 	usersLock:        sync.Mutex{},
 	shared: SharedData{
 		pool:          db.GetConnection(),
-		corev1Client:  config.GetCoreClient(),
 		dynamicClient: config.GetDynamicClient(),
 	},
 	users:      map[string]*UserDataCache{},


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  N/A

### Description of changes
- Replace the kube `corev1Client` with the `dynamicClient` to simplify and avoid using different clients.
