### PR TITLE
Simplify tokenreview cache

### DIFF
--- a/pkg/rbac/tokenReview_test.go
+++ b/pkg/rbac/tokenReview_test.go
@@ -43,7 +43,7 @@ func Test_IsValidToken_usingCache(t *testing.T) {
 	// Initialize cache and set state.
 	mock_cache := newMockCache()
 	mock_cache.tokenReviews["1234567890"] = &tokenReviewCache{
-		updatedAt: time.Now(),
+		meta: cacheMetadata{updatedAt: time.Now()},
 		tokenReview: &authv1.TokenReview{
 			Status: authv1.TokenReviewStatus{
 				Authenticated: true,
@@ -69,7 +69,7 @@ func Test_IsValidToken_expiredCache(t *testing.T) {
 	mock_cache := newMockCache()
 	mock_cache.tokenReviews["1234567890-expired"] = &tokenReviewCache{
 		authClient: fake.NewSimpleClientset().AuthenticationV1(),
-		updatedAt:  time.Now().Add(time.Duration(-5) * time.Minute),
+		meta:       cacheMetadata{updatedAt: time.Now().Add(time.Duration(-5) * time.Minute)},
 		token:      "1234567890-expired",
 		tokenReview: &authv1.TokenReview{
 			Status: authv1.TokenReviewStatus{
@@ -89,7 +89,7 @@ func Test_IsValidToken_expiredCache(t *testing.T) {
 		t.Error("Received unexpected error from IsValidToken()", err)
 	}
 	// Verify that cache was updated within the last 1 millisecond.
-	if mock_cache.tokenReviews["1234567890-expired"].updatedAt.Before(time.Now().Add(time.Duration(-1) * time.Millisecond)) {
+	if mock_cache.tokenReviews["1234567890-expired"].meta.updatedAt.Before(time.Now().Add(time.Duration(-1) * time.Millisecond)) {
 		t.Error("Expected the cached TokenReview to be updated within the last millisecond.")
 	}
 

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -35,7 +35,7 @@ func setupToken(cache *Cache) *Cache {
 		cache.tokenReviews = map[string]*tokenReviewCache{}
 	}
 	cache.tokenReviews["123456"] = &tokenReviewCache{
-		updatedAt:  time.Now(),
+		meta:       cacheMetadata{updatedAt: time.Now()},
 		authClient: fake.NewSimpleClientset().AuthenticationV1(),
 		tokenReview: &authv1.TokenReview{
 			Status: authv1.TokenReviewStatus{


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  N/A

### Description of changes
- Use common `cacheMetadata` to manage the tokenReview cache.
