### PR TITLE
ACM-3071 Rename DB_MAX_CONNS to be consistent with indexer

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,9 +20,9 @@ type Config struct {
 	AuthCacheTTL   int    // Time-to-live (milliseconds) of Authentication (TokenReview) cache.
 	SharedCacheTTL int    // Time-to-live (milliseconds) of common resources (shared across users) cache.
 	UserCacheTTL   int    // Time-to-live (milliseconds) of namespaced resources (specifc to users) cache.
-	MaxConns       int
 	ContextPath    string
 	DBHost         string
+	DBMaxConns     int // Max size of DB connection pool. Default: 10
 	DBName         string
 	DBPass         string
 	DBPort         int
@@ -45,9 +45,9 @@ func new() *Config {
 		AuthCacheTTL:   getEnvAsInt("AUTH_CACHE_TTL", int(60000)),    // 1 minute
 		SharedCacheTTL: getEnvAsInt("SHARED_CACHE_TTL", int(120000)), // 2 min (increase to 10min after implementation)
 		UserCacheTTL:   getEnvAsInt("USER_CACHE_TTL", int(120000)),   // 2 min (increase to 10min after implementation)
-		MaxConns:       getEnvAsInt("MAX_CONNS", int(10)),
 		ContextPath:    getEnv("CONTEXT_PATH", "/searchapi"),
 		DBHost:         getEnv("DB_HOST", "localhost"),
+		DBMaxConns:     getEnvAsInt("DB_MAX_CONNS", int(10)), // Postgres has 100 conns. Allow for scaling the indexer.
 		DBName:         getEnv("DB_NAME", ""),
 		DBPass:         getEnv("DB_PASS", ""),
 		DBPort:         getEnvAsInt("DB_PORT", int(5432)),

--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -36,7 +36,7 @@ func initializePool(ctx context.Context) {
 		klog.Error("Error parsing database connection configuration.", configErr)
 	}
 
-	config.MaxConns = int32(cfg.MaxConns)
+	config.MaxConns = int32(cfg.DBMaxConns)
 	conn, err := pgxpool.ConnectConfig(ctx, config)
 	if err != nil {
 		klog.Errorf("Unable to connect to database: %+v\n", err)


### PR DESCRIPTION
Signed-off-by: Jorge Padilla <jpadilla@redhat.com>

**Related Issue:**  https://issues.redhat.com/browse/ACM-3071

### Description of changes
- Rename `DB_MAX_CONNS` to be consistent with recent change in indexer.
