### PR TITLE
ACM-3228 Add prometheus metrics middleware to capture request duration and response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,43 @@ spec:
       - name: multiclusterhub-operator-pull-secret
 ```
 
+
+
+Metrics
+==================
+
+Search-v2-api also monitors and exports various metrics to Prometheus. Below are the metrics currently exported from search-v2-api.
+
+**Histograms**:
+
+* `search_http_duration_seconds` - Latency of of HTTP requests in seconds.
+  * Labels:
+    * **code**: Status code generated from request
+    * TODO: **query_type**: Type of query requested 
+
+* `search_dbquery_duration_seconds` - Latency of DB requests in seconds.
+  * Labels:
+    * TODO: **query_name**: Name of database query
+
+Example: The following metric will record all search queries created in under or equal to 0.1 seconds
+```
+http_request_duration_seconds_bucket{
+    query_type="searchComplete",
+    code="200",
+    le="0.1"
+}
+```
+**Counters**:
+
+* `search_db_connection_failed_total` - The total number of DB connection that has failed
+  * Labels:
+    * TODO:**route**: Route associated with DB connection failure.
+
+
+To view these metrics, with the search api pod and database running, run the following command:
+
+`curl https://localhost:4010/metrics -k | grep search_`
+
+
+
 Rebuild Date: 2022-08-16

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -82,6 +83,7 @@ require (
 	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/tools v0.1.12 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
@@ -1108,6 +1109,8 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/database/connection.go
+++ b/pkg/database/connection.go
@@ -49,7 +49,6 @@ func initializePool(ctx context.Context) {
 func GetConnPool(ctx context.Context) *pgxpool.Pool {
 	if pool == nil {
 		initializePool(ctx)
-		metric.DBConnectionSuccess.WithLabelValues("DBConnect").Inc()
 	}
 
 	if pool != nil {
@@ -63,7 +62,6 @@ func GetConnPool(ctx context.Context) *pgxpool.Pool {
 			metric.DBConnectionFailed.WithLabelValues("DBPing").Inc()
 			return nil
 		}
-		metric.DBConnectionSuccess.WithLabelValues("DBPing").Inc()
 		timeLastPing = time.Now()
 		klog.Info("Successfully connected to database!")
 	}

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -10,13 +10,6 @@ var (
 	HttpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "search_http_duration_seconds",
 		Help: "Latency of of HTTP requests in seconds.",
-	}, []string{"code", "query_type"})
-)
-
-var (
-	HttpRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "search_http_total",
-		Help: "Total number HTTP requests.",
 	}, []string{"code"})
 )
 
@@ -31,5 +24,5 @@ var (
 	DBQueryDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "search_dbquery_duration_seconds",
 		Help: "Latency of DB requests in seconds.",
-	}, []string{"query"})
+	}, []string{"query_name"})
 )

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -10,14 +10,14 @@ var (
 	HttpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "search_http_duration_seconds",
 		Help: "Latency of of HTTP requests in seconds.",
-	}, []string{"path", "method"})
+	}, []string{"code"})
 )
 
 var (
 	HttpRequestTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "search_http_total",
 		Help: "Total number HTTP requests.",
-	}, []string{"path", "method"})
+	}, []string{"code"})
 )
 
 var (

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -10,7 +10,7 @@ var (
 	HttpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "search_http_duration_seconds",
 		Help: "Latency of of HTTP requests in seconds.",
-	}, []string{"code"})
+	}, []string{"code", "query_type"})
 )
 
 var (

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -21,32 +21,12 @@ var (
 )
 
 var (
-	AuthnFailed = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "search_authn_failed_total",
-		Help: "The total number of authentication requests that has failed",
-	}, []string{"reason"})
-)
-
-var (
-	AuthzFailed = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "search_authz_failed_total",
-		Help: "The total number of authorization requests that has failed",
-	}, []string{"reason"})
-)
-
-var (
 	DBConnectionFailed = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "search_db_connection_failed_total",
 		Help: "The total number of DB connection that has failed",
 	}, []string{"route"})
 )
 
-var (
-	DBConnectionSuccess = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "search_db_connection_success_total",
-		Help: "The total number of DB connection that has succeeded",
-	}, []string{"route"})
-)
 var (
 	DBQueryDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "search_dbquery_duration_seconds",

--- a/pkg/metric/middleware.go
+++ b/pkg/metric/middleware.go
@@ -6,20 +6,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-type metricsResponseWriter struct {
-	http.ResponseWriter
-	statusCode int
-}
-
-func NewMetricsResponseWriter(w http.ResponseWriter) *metricsResponseWriter {
-	return &metricsResponseWriter{w, 0}
-}
-
-func (lrw *metricsResponseWriter) WriteHeader(code int) {
-	lrw.statusCode = code
-	lrw.ResponseWriter.WriteHeader(code)
-}
-
 // prometheusMiddleware implements mux.MiddlewareFunc.
 func PrometheusMiddleware(next http.Handler) http.Handler {
 

--- a/pkg/metric/middleware.go
+++ b/pkg/metric/middleware.go
@@ -12,6 +12,8 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 
 	queryType := "searchWithRelationship" // TODO: Need to extract this from the request.
 	duration, _ := HttpDuration.CurryWith(prometheus.Labels{"query_type": queryType})
+	// InstrumentHandlerDuration is a middleware that wraps the provided http.Handler to observe the
+	// request duration with the provided ObserverVec.
 	return promhttp.InstrumentHandlerDuration(duration,
 		promhttp.InstrumentHandlerCounter(HttpRequestTotal, next))
 }

--- a/pkg/metric/middleware.go
+++ b/pkg/metric/middleware.go
@@ -3,12 +3,15 @@ package metric
 import (
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// prometheusMiddleware implements mux.MiddlewareFunc.
+// Instrument with prom middleware to capture request metrics.
 func PrometheusMiddleware(next http.Handler) http.Handler {
 
-	return promhttp.InstrumentHandlerDuration(HttpDuration,
+	queryType := "searchWithRelationship" // TODO: Need to extract this from the request.
+	duration, _ := HttpDuration.CurryWith(prometheus.Labels{"query_type": queryType})
+	return promhttp.InstrumentHandlerDuration(duration,
 		promhttp.InstrumentHandlerCounter(HttpRequestTotal, next))
 }

--- a/pkg/metric/middleware.go
+++ b/pkg/metric/middleware.go
@@ -3,17 +3,13 @@ package metric
 import (
 	"net/http"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Instrument with prom middleware to capture request metrics.
 func PrometheusMiddleware(next http.Handler) http.Handler {
 
-	queryType := "searchWithRelationship" // TODO: Need to extract this from the request.
-	duration, _ := HttpDuration.CurryWith(prometheus.Labels{"query_type": queryType})
 	// InstrumentHandlerDuration is a middleware that wraps the provided http.Handler to observe the
 	// request duration with the provided ObserverVec.
-	return promhttp.InstrumentHandlerDuration(duration,
-		promhttp.InstrumentHandlerCounter(HttpRequestTotal, next))
+	return promhttp.InstrumentHandlerDuration(HttpDuration, next)
 }

--- a/pkg/metric/middleware.go
+++ b/pkg/metric/middleware.go
@@ -6,21 +6,41 @@ import (
 	klog "k8s.io/klog/v2"
 
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+type metricsResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func NewMetricsResponseWriter(w http.ResponseWriter) *metricsResponseWriter {
+	return &metricsResponseWriter{w, http.StatusOK}
+}
+
+func (lrw *metricsResponseWriter) WriteHeader(code int) {
+	lrw.statusCode = code
+	lrw.ResponseWriter.WriteHeader(code)
+}
 
 // prometheusMiddleware implements mux.MiddlewareFunc.
 func PrometheusMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		klog.Info("At PrometheusMiddleware BEFORE processing the request.")
 		route := mux.CurrentRoute(r)
 		path, _ := route.GetPathTemplate()
-		klog.V(4).Infof("URL Referrer: %s", r.Referer())
-		klog.V(4).Infof("User Agent: %s", r.UserAgent())
-		//Not working as intended. This does not capture the time taken by the entire call.
-		//it only captures the time taken inside this call.
-		/* timer := prometheus.NewTimer(HttpDuration.WithLabelValues(path, r.Method))
-		timer.ObserveDuration()*/
-		HttpRequestTotal.WithLabelValues(path, r.Method).Inc()
-		next.ServeHTTP(w, r)
 
+		timer := prometheus.NewTimer(HttpDuration.WithLabelValues(path, r.Method))
+		HttpRequestTotal.WithLabelValues(path, r.Method).Inc()
+
+		metricsRespWriter := NewMetricsResponseWriter(w)
+
+		// This will run at the end of the middleware chain.
+		defer func() {
+			klog.Infof("At prom middleware AFTER processing the request. response_code  %+v", metricsRespWriter.statusCode)
+			timer.ObserveDuration()
+		}()
+
+		next.ServeHTTP(metricsRespWriter, r)
 	})
 }

--- a/pkg/metric/middleware_test.go
+++ b/pkg/metric/middleware_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	// "github.com/prometheus/client_golang/prometheus/promauto"
 	"gotest.tools/assert"
 )
 
@@ -16,9 +15,9 @@ func Test_DurationCode(t *testing.T) {
 
 	// mock http handler
 	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	// create a mock resquest to pass to handler
+	// Create a mock resquest to pass to handler.
 	r := httptest.NewRequest("POST", "https://localhost:4010/searchapi/graphql", nil)
-	// create response recorder so we can get status code and serve mock request
+	// Create response recorder so we can get status code and serve mock request.
 	resp := httptest.NewRecorder()
 
 	// Execute middleware function.
@@ -26,10 +25,10 @@ func Test_DurationCode(t *testing.T) {
 	promMiddle.ServeHTTP(resp, r)
 
 	// Validate result.
-	// use the prometheus registry to confirm metrics have been scraped:
+	// use the prometheus registry to confirm metrics have been scraped.
 	metricFamilies, _ := registry.Gather()
 	for _, mf := range metricFamilies {
-		//assert our metric got collected:
+		// assert our metric got collected:
 		assert.Equal(t, mf.GetName(), "http_request_duration_seconds_test")
 
 		for _, v := range mf.Metric[0].GetLabel() {
@@ -45,5 +44,4 @@ func Test_DurationCode(t *testing.T) {
 			assert.Equal(t, uint64(1), m.GetHistogram().GetSampleCount())
 		}
 	}
-
 }

--- a/pkg/metric/middleware_test.go
+++ b/pkg/metric/middleware_test.go
@@ -1,0 +1,84 @@
+package metric
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"gotest.tools/assert"
+)
+
+func TestDurationCode(t *testing.T) {
+
+	registry := prometheus.NewRegistry()
+
+	// mock http handler:
+	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	//mock HistogramVec
+	durationHistogram := promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "http_request_duration_seconds_test",
+			Help: "Duration of my request in seconds.",
+		},
+		[]string{"code", "query_type"},
+	)
+	registry.MustRegister(durationHistogram)
+
+	//add mock label
+	duration, _ := durationHistogram.CurryWith(prometheus.Labels{"query_type": "mock_query"})
+
+	// mock instrumentHandlerDuration with mock observervec
+	instrumentedHandler := promhttp.InstrumentHandlerDuration(
+		duration,
+		httpHandler,
+	)
+
+	//create a mock resquest to pass to handler:
+	r, err := http.NewRequest("GET", "https://localhost:4010/searchapi/graphql", nil)
+	if err != nil {
+		t.Fatal(err)
+
+	}
+	// create response recorder so we can get status code and serve mock request
+	resp := httptest.NewRecorder()
+	instrumentedHandler.ServeHTTP(resp, r)
+
+	// use the prometheus registry to confirm metrics have been scraped:
+	metricFamilies, _ := registry.Gather()
+
+	for _, mf := range metricFamilies {
+
+		//assert our metric got collected:
+		assert.Equal(t, mf.GetName(), "http_request_duration_seconds_test")
+
+		//assert only one metric: probably redundant
+		// assert.Equal(t, 1, len(mf.GetMetric()))
+
+		for _, v := range mf.Metric[0].GetLabel() {
+
+			//assert label code is 200
+			if *v.Name == "code" {
+				val := *v.Value
+				assert.Equal(t, strconv.Itoa(resp.Code), val)
+			}
+			//assert label query_type is mock_query
+			if *v.Name == "query_type" {
+				val := *v.Value
+				assert.Equal(t, "mock_query", val)
+			}
+
+		}
+
+		for _, m := range mf.GetMetric() {
+			//assert count of metric is one (one request)
+			assert.Equal(t, uint64(1), m.GetHistogram().GetSampleCount())
+		}
+
+	}
+
+}

--- a/pkg/metric/middleware_test.go
+++ b/pkg/metric/middleware_test.go
@@ -38,6 +38,8 @@ func TestDurationCode(t *testing.T) {
 		httpHandler,
 	)
 
+	promMiddle := PrometheusMiddleware(instrumentedHandler)
+
 	//create a mock resquest to pass to handler:
 	r, err := http.NewRequest("GET", "https://localhost:4010/searchapi/graphql", nil)
 	if err != nil {
@@ -46,7 +48,7 @@ func TestDurationCode(t *testing.T) {
 	}
 	// create response recorder so we can get status code and serve mock request
 	resp := httptest.NewRecorder()
-	instrumentedHandler.ServeHTTP(resp, r)
+	promMiddle.ServeHTTP(resp, r)
 
 	// use the prometheus registry to confirm metrics have been scraped:
 	metricFamilies, _ := registry.Gather()

--- a/pkg/metric/middleware_test.go
+++ b/pkg/metric/middleware_test.go
@@ -7,65 +7,43 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	// "github.com/prometheus/client_golang/prometheus/promauto"
 	"gotest.tools/assert"
 )
 
-func TestDurationCode(t *testing.T) {
-
+func Test_DurationCode(t *testing.T) {
 	registry := prometheus.NewRegistry()
 
-	// mock http handler:
+	// mock http handler
 	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-
-	//mock HistogramVec
-	durationHistogram := promauto.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "http_request_duration_seconds_test",
-			Help: "Duration of my request in seconds.",
-		},
-		[]string{"code"},
-	)
-	registry.MustRegister(durationHistogram)
-
-	promMiddle := PrometheusMiddleware(httpHandler)
-
-	//create a mock resquest to pass to handler:
-	r, err := http.NewRequest("GET", "https://localhost:4010/searchapi/graphql", nil)
-	if err != nil {
-		t.Fatal(err)
-
-	}
+	// create a mock resquest to pass to handler
+	r := httptest.NewRequest("POST", "https://localhost:4010/searchapi/graphql", nil)
 	// create response recorder so we can get status code and serve mock request
 	resp := httptest.NewRecorder()
+
+	// Execute middleware function.
+	promMiddle := PrometheusMiddleware(httpHandler)
 	promMiddle.ServeHTTP(resp, r)
 
+	// Validate result.
 	// use the prometheus registry to confirm metrics have been scraped:
 	metricFamilies, _ := registry.Gather()
-
 	for _, mf := range metricFamilies {
-
 		//assert our metric got collected:
 		assert.Equal(t, mf.GetName(), "http_request_duration_seconds_test")
 
-		//assert only one metric: probably redundant
-		// assert.Equal(t, 1, len(mf.GetMetric()))
-
 		for _, v := range mf.Metric[0].GetLabel() {
-
-			//assert label code is 200
+			// assert label code is 200
 			if *v.Name == "code" {
 				val := *v.Value
 				assert.Equal(t, strconv.Itoa(resp.Code), val)
 			}
-
 		}
 
 		for _, m := range mf.GetMetric() {
-			//assert count of metric is one (one request)
+			// assert count of metric is one (one request)
 			assert.Equal(t, uint64(1), m.GetHistogram().GetSampleCount())
 		}
-
 	}
 
 }

--- a/pkg/rbac/authnMiddleware.go
+++ b/pkg/rbac/authnMiddleware.go
@@ -4,10 +4,8 @@ package rbac
 import (
 	"context"
 	"net/http"
-	"strconv"
 	"strings"
 
-	"github.com/stolostron/search-v2-api/pkg/metric"
 	"k8s.io/klog/v2"
 )
 
@@ -35,7 +33,6 @@ func AuthenticateUser(next http.Handler) http.Handler {
 			klog.V(4).Info("Request didn't have a valid authentication token.")
 			http.Error(w, "{\"message\":\"Request didn't have a valid authentication token.\"}",
 				http.StatusUnauthorized)
-			metric.AuthnFailed.WithLabelValues(strconv.Itoa(http.StatusUnauthorized)).Inc()
 			return
 		}
 
@@ -44,14 +41,12 @@ func AuthenticateUser(next http.Handler) http.Handler {
 			klog.Warning("Unexpected error while authenticating the request token.", err)
 			http.Error(w, "{\"message\":\"Unexpected error while authenticating the request token.\"}",
 				http.StatusInternalServerError)
-			metric.AuthnFailed.WithLabelValues(strconv.Itoa(http.StatusInternalServerError)).Inc()
 			return
 
 		}
 		if !authenticated {
 			klog.V(4).Info("Rejecting request: Invalid token.")
 			http.Error(w, "{\"message\":\"Invalid token\"}", http.StatusForbidden)
-			metric.AuthnFailed.WithLabelValues(strconv.Itoa(http.StatusForbidden)).Inc()
 			return
 		}
 


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-3228

### Description of changes
- Add prometheus metrics middleware to capture request duration and response code

### Test
Send a query with invalid auth token
```
$ curl --insecure --location \ 
--request POST $URL \
--header "Authorization: Bearer $TOKEN" --header 'Content-Type: application/json' \
--data-raw '{"query":"query q($input: [SearchInput]) { search(input: $input) { count } }","variables":{"input":[{"keywords":[],"filters":[{"property":"kind","values":["ConfigMap"]}]}]}}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   201  100    28  100   173    139    860 --:--:-- --:--:-- --:--:--  1020
{
  "message": "Invalid token"
}
```

Get the metrics
```
 $ curl --insecure --location --request GET https://localhost:4010/metrics |grep search_http    

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6421    0  6421    0     0   224k      0 --:--:-- --:--:-- --:--:--  250k
# HELP search_http_duration_seconds Latency of of HTTP requests in seconds.
# TYPE search_http_duration_seconds histogram
search_http_duration_seconds_bucket{code="403",le="0.005"} 0
search_http_duration_seconds_bucket{code="403",le="0.01"} 0
search_http_duration_seconds_bucket{code="403",le="0.025"} 0
search_http_duration_seconds_bucket{code="403",le="0.05"} 0
search_http_duration_seconds_bucket{code="403",le="0.1"} 0
search_http_duration_seconds_bucket{code="403",le="0.25"} 1
search_http_duration_seconds_bucket{code="403",le="0.5"} 1
search_http_duration_seconds_bucket{code="403",le="1"} 1
search_http_duration_seconds_bucket{code="403",le="2.5"} 1
search_http_duration_seconds_bucket{code="403",le="5"} 1
search_http_duration_seconds_bucket{code="403",le="10"} 1
search_http_duration_seconds_bucket{code="403",le="+Inf"} 1
search_http_duration_seconds_sum{code="403"} 0.121522541
search_http_duration_seconds_count{code="403"} 1
# HELP search_http_total Total number HTTP requests.
# TYPE search_http_total counter
search_http_total{code="403"} 1
```

