### PR TITLE
ACM-3288 Exclude scraping requests from prom data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,16 @@ help:
 setup: ## Generate ssl certificate for development.
 	cd sslcert; openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -config req.conf -extensions 'v3_req'
 
+setup-dev: ## Configure local environment to use the postgres instance on the dev cluster.
+	@echo "Using current target cluster.\\n"
+	@echo "$(shell oc cluster-info)"
+	@echo "\\n1. [MANUAL STEP] Set these environment variables.\\n"
+	export DB_NAME=$(shell oc get secret search-postgres -n open-cluster-management -o jsonpath='{.data.database-name}'|base64 -D)
+	export DB_USER=$(shell oc get secret search-postgres -n open-cluster-management -o jsonpath='{.data.database-user}'|base64 -D)
+	export DB_PASS=$(shell oc get secret search-postgres -n open-cluster-management -o jsonpath='{.data.database-password}'|base64 -D)
+	@echo "\\n2. [MANUAL STEP] Start port forwarding.\\n"
+	@echo "oc port-forward service/search-postgres -n open-cluster-management 5432:5432 \\n"
+
 gqlgen: ## Generate graphql model. See: https://gqlgen.com/
 	go run github.com/99designs/gqlgen generate
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ search_api_requests_bucket{
 ```
 **Counters**:
 
-* `search_db_connection_failed_total` - The total number of DB connection that has failed
+* `search_api_db_connection_failed_total` - The total number of DB connection that has failed
   * Labels:
     * TODO:**route**: Route associated with DB connection failure.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Search-v2-api also monitors and exports various metrics to Prometheus. Below are
 
 **Histograms**:
 
-* `search_http_duration_seconds` - Latency of of HTTP requests in seconds.
+* `search_api_requests` - Histogram of HTTP requests duration (seconds).
   * Labels:
     * **code**: Status code generated from request
     * TODO: **query_type**: Type of query requested 
@@ -110,7 +110,7 @@ Search-v2-api also monitors and exports various metrics to Prometheus. Below are
 
 Example: The following metric will record all search queries created in under or equal to 0.1 seconds
 ```
-http_request_duration_seconds_bucket{
+search_api_requests_bucket{
     query_type="searchComplete",
     code="200",
     le="0.1"

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -7,22 +7,33 @@ import (
 )
 
 var (
-	HttpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "search_http_duration_seconds",
-		Help: "Latency of of HTTP requests in seconds.",
+	HttpRequestsHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "search_api_requests",
+		Help: "Histogram of HTTP requests duration (seconds).",
 	}, []string{"code"})
 )
 
 var (
 	DBConnectionFailed = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "search_db_connection_failed_total",
+		Name: "search_api_db_connection_failed_total",
 		Help: "The total number of DB connection that has failed",
 	}, []string{"route"})
 )
 
 var (
 	DBQueryDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "search_dbquery_duration_seconds",
+		Name: "search_api_dbquery_duration_seconds",
 		Help: "Latency of DB requests in seconds.",
 	}, []string{"query_name"})
 )
+
+// var (
+// 	promRegistry = prometheus.NewRegistry()
+// )
+
+func GetPromRegistry() *prometheus.Registry {
+	r := prometheus.NewRegistry()
+	r.MustRegister(HttpRequestsHistogram)
+
+	return r
+}

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -7,33 +7,20 @@ import (
 )
 
 var (
-	HttpRequestsHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	PromRegistry = prometheus.NewRegistry()
+
+	HttpRequestsHistogram = promauto.With(PromRegistry).NewHistogramVec(prometheus.HistogramOpts{
 		Name: "search_api_requests",
 		Help: "Histogram of HTTP requests duration (seconds).",
 	}, []string{"code"})
-)
 
-var (
-	DBConnectionFailed = promauto.NewCounterVec(prometheus.CounterOpts{
+	DBConnectionFailed = promauto.With(PromRegistry).NewCounterVec(prometheus.CounterOpts{
 		Name: "search_api_db_connection_failed_total",
-		Help: "The total number of DB connection that has failed",
+		Help: "The total number of DB connections that has failed.",
 	}, []string{"route"})
-)
 
-var (
-	DBQueryDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "search_api_dbquery_duration_seconds",
-		Help: "Latency of DB requests in seconds.",
+	DBQueryDuration = promauto.With(PromRegistry).NewHistogramVec(prometheus.HistogramOpts{
+		Name: "search_api_dbquery_duration",
+		Help: "Histogram of outbound DB query latency (seconds).",
 	}, []string{"query_name"})
 )
-
-// var (
-// 	promRegistry = prometheus.NewRegistry()
-// )
-
-func GetPromRegistry() *prometheus.Registry {
-	r := prometheus.NewRegistry()
-	r.MustRegister(HttpRequestsHistogram)
-
-	return r
-}

--- a/pkg/metric/middleware.go
+++ b/pkg/metric/middleware.go
@@ -11,5 +11,5 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 
 	// InstrumentHandlerDuration is a middleware that wraps the provided http.Handler to observe the
 	// request duration with the provided ObserverVec.
-	return promhttp.InstrumentHandlerDuration(HttpDuration, next)
+	return promhttp.InstrumentHandlerDuration(HttpRequestsHistogram, next)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,7 +36,7 @@ func StartAndListen() {
 	router := mux.NewRouter()
 	router.HandleFunc("/liveness", livenessProbe).Methods("GET")
 	router.HandleFunc("/readiness", readinessProbe).Methods("GET")
-	router.Handle("/metrics", promhttp.HandlerFor(metric.GetPromRegistry(), promhttp.HandlerOpts{}))
+	router.Handle("/metrics", promhttp.HandlerFor(metric.PromRegistry, promhttp.HandlerOpts{}))
 
 	if config.Cfg.PlaygroundMode {
 		router.Handle("/playground",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,7 +36,7 @@ func StartAndListen() {
 	router := mux.NewRouter()
 	router.HandleFunc("/liveness", livenessProbe).Methods("GET")
 	router.HandleFunc("/readiness", readinessProbe).Methods("GET")
-	router.Path("/metrics").Handler(promhttp.Handler())
+	router.Handle("/metrics", promhttp.HandlerFor(metric.GetPromRegistry(), promhttp.HandlerOpts{}))
 
 	if config.Cfg.PlaygroundMode {
 		router.Handle("/playground",


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-3288

### Description of changes
- Use a custom prometheus registry to exclude scraping requests (/metrics) from the returned data.
- Rename metric
- Add Make target to setup database for local dev.
