### PR TITLE
ACM-4523 Capture remoteAddr and userAgent in request metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,14 @@ test-scale-ui: check-locust ## Start Locust and open the web browser to drive sc
 test-scale-setup: ## Creates the search-api route in the current target cluster.
 	oc create route passthrough search-api --service=search-search-api -n open-cluster-management
 
+test-send: ## Sends a graphQL query using cURL for development testing.
+	URL=https://localhost:4010/searchapi/graphql \
+	TOKEN=$(shell oc whoami -t) \
+	curl --insecure --location --request POST ${URL} \
+	--header "Authorization: Bearer ${TOKEN}" --header 'Content-Type: application/json' \
+	--data-raw '{"query":"query q($$input: [SearchInput]) { search(input: $$input) { count items } }","variables":{"input":[{"keywords":[],"filters":[{"property":"kind","values":["ConfigMap"]}],"limit": 3}]}}' | jq
+
+
 check-locust: ## Checks if Locust is installed in the system.
 ifeq (,$(shell which locust))
 	@echo The scale tests require Locust.io, but locust was not found.

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ coverage: test ## Run unit tests and show code coverage.
 docker-build: ## Build the docker image.
 	docker build -f Dockerfile . -t search-v2-api
 
+show-metrics:
+	curl -k https://localhost:4010/metrics
+
 N_USERS ?=2
 HOST ?= $(shell oc get route search-api -o custom-columns=host:.spec.host --no-headers -n open-cluster-management --ignore-not-found=true --request-timeout='1s')
 ifeq ($(strip $(HOST)),)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,7 +12,7 @@ var (
 	RequestDuration = promauto.With(PromRegistry).NewHistogramVec(prometheus.HistogramOpts{
 		Name: "search_api_request_duration",
 		Help: "Time (seconds) the search api took to process the request",
-	}, []string{"code"})
+	}, []string{"code", "remoteAddr", "userAgent"})
 
 	DBConnectionFailed = promauto.With(PromRegistry).NewCounter(prometheus.CounterOpts{
 		Name: "search_api_db_connection_failed",

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -13,7 +13,7 @@ import (
 func PrometheusMiddleware(next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		klog.Infof("Received request. User-Agent: %s RemoteAddr: %s", r.UserAgent(), r.RemoteAddr)
+		klog.V(5).Infof("Received request. User-Agent: %s RemoteAddr: %s", r.UserAgent(), r.RemoteAddr)
 
 		curriedRequestDuration, err := RequestDuration.CurryWith(prometheus.Labels{
 			"remoteAddr": r.RemoteAddr[0:strings.LastIndex(r.RemoteAddr, ":")], // Remove port

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
-
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog/v2"
 )

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -17,10 +17,10 @@ func PrometheusMiddleware(next http.Handler) http.Handler {
 
 		curriedRequestDuration, err := RequestDuration.CurryWith(prometheus.Labels{
 			"remoteAddr": r.RemoteAddr[0:strings.LastIndex(r.RemoteAddr, ":")], // Remove port
-			// "userAgent":  r.UserAgent(),
+			"userAgent":  r.UserAgent(),
 		})
 		if err != nil {
-			klog.Error("Error while curring RequestDuration metric with remoteAddr label. ", err)
+			klog.Error("Error while curring the RequestDuration metric with remoteAddr label. ", err)
 		}
 		h := promhttp.InstrumentHandlerDuration(curriedRequestDuration, next)
 		h.ServeHTTP(w, r)

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -3,13 +3,22 @@ package metrics
 import (
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/klog/v2"
 )
 
 // Instrument with prom middleware to capture request metrics.
 func PrometheusMiddleware(next http.Handler) http.Handler {
 
-	// InstrumentHandlerDuration is a middleware that wraps the provided http.Handler to observe the
-	// request duration with the provided ObserverVec.
-	return promhttp.InstrumentHandlerDuration(RequestDuration, next)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		klog.Infof("Received request. User-Agent: %s RemoreAddr: %s", r.UserAgent(), r.RemoteAddr)
+		curriedRequestDuration, err := RequestDuration.CurryWith(prometheus.Labels{"remoteAddr": r.RemoteAddr, "userAgent": r.UserAgent()})
+		if err != nil {
+			klog.Error("Error while curring RequestDuration metric with remoteAddr label. ", err)
+		}
+		h := promhttp.InstrumentHandlerDuration(curriedRequestDuration, next)
+		h.ServeHTTP(w, r)
+	})
 }

--- a/pkg/metrics/middleware.go
+++ b/pkg/metrics/middleware.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -13,8 +14,12 @@ import (
 func PrometheusMiddleware(next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		klog.Infof("Received request. User-Agent: %s RemoreAddr: %s", r.UserAgent(), r.RemoteAddr)
-		curriedRequestDuration, err := RequestDuration.CurryWith(prometheus.Labels{"remoteAddr": r.RemoteAddr, "userAgent": r.UserAgent()})
+		klog.Infof("Received request. User-Agent: %s RemoteAddr: %s", r.UserAgent(), r.RemoteAddr)
+
+		curriedRequestDuration, err := RequestDuration.CurryWith(prometheus.Labels{
+			"remoteAddr": r.RemoteAddr[0:strings.LastIndex(r.RemoteAddr, ":")], // Remove port
+			// "userAgent":  r.UserAgent(),
+		})
 		if err != nil {
 			klog.Error("Error while curring RequestDuration metric with remoteAddr label. ", err)
 		}

--- a/pkg/metrics/middleware_test.go
+++ b/pkg/metrics/middleware_test.go
@@ -29,7 +29,7 @@ func Test_PrometheusInstrumentation(t *testing.T) {
 
 	// METRIC 2:  search_api_request_duration
 	assert.Equal(t, "search_api_request_duration", collectedMetrics[1].GetName())
-	assert.Equal(t, 1, len(collectedMetrics[1].Metric[0].GetLabel()))
+	assert.Equal(t, 3, len(collectedMetrics[1].Metric[0].GetLabel()))
 	assert.Equal(t, "code", *collectedMetrics[1].Metric[0].GetLabel()[0].Name)
 	assert.Equal(t, "200", *collectedMetrics[1].Metric[0].GetLabel()[0].Value)
 	assert.Equal(t, uint64(1), collectedMetrics[1].Metric[0].GetHistogram().GetSampleCount())


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-4523

### Description of changes
Add remoteAddr and userAgent labels to request metrics.

![image](https://user-images.githubusercontent.com/4671325/231577301-316a9f0f-80d9-42ef-9cd3-fc30536aec54.png)

