### PR TITLE
ACM-7062: Special RBAC handling for global search user

### DIFF
--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -156,7 +156,7 @@ func (user *UserDataCache) userHasAllAccess(ctx context.Context, cache *Cache) (
 		user.ManagedClusters = map[string]struct{}{"*": {}}
 		user.clustersCache.updatedAt = time.Now()
 		user.csrCache.err, user.nsrCache.err, user.clustersCache.err = nil, nil, nil
-		klog.V(5).Infof("User %s with uid %s has *list* access to all managed cluster resources.",
+		klog.V(5).Infof("User %s with uid %s has access to all resources.",
 			user.userInfo.Username, user.userInfo.UID)
 
 		return true, nil
@@ -177,7 +177,7 @@ func (user *UserDataCache) userHasAllAccess(ctx context.Context, cache *Cache) (
 		user.ManagedClusters = map[string]struct{}{"*": {}}
 		user.clustersCache.updatedAt = time.Now()
 		user.csrCache.err, user.nsrCache.err, user.clustersCache.err = nil, nil, nil
-		klog.V(5).Infof("User %s with uid %s has *get* access to all managed cluster resources.",
+		klog.V(5).Infof("User %s with uid %s is authorized to search/allManagedData which gives access to all managed cluster resources.",
 			user.userInfo.Username, user.userInfo.UID)
 		return true, nil
 	}

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -161,7 +161,7 @@ func (user *UserDataCache) userHasAllAccess(ctx context.Context, cache *Cache) (
 
 		return true, nil
 	} else if user.userAuthorizedListSSAR(ctx, impersClientSet,
-		"get", "search.open-cluster-management.io", "search.search.open-cluster-management.io/allManagedData") {
+		"get", "searches", "searches/allManagedData") {
 		user.csrCache.lock.Lock()
 		defer user.csrCache.lock.Unlock()
 		user.CsResources = []Resource{}

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -257,13 +257,13 @@ func (user *UserDataCache) getClusterScopedResources(ctx context.Context, cache 
 }
 
 func (user *UserDataCache) userAuthorizedListSSAR(ctx context.Context, authzClient v1.AuthorizationV1Interface,
-	verb string, apigroup string, kind_plural string) bool {
+	verb string, apigroup string, kindPlural string) bool {
 	accessCheck := &authz.SelfSubjectAccessReview{
 		Spec: authz.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authz.ResourceAttributes{
 				Verb:     verb,
 				Group:    apigroup,
-				Resource: kind_plural,
+				Resource: kindPlural,
 			},
 		},
 	}
@@ -273,7 +273,7 @@ func (user *UserDataCache) userAuthorizedListSSAR(ctx context.Context, authzClie
 		klog.Error("Error creating SelfSubjectAccessReviews.", err)
 	} else {
 		klog.V(6).Infof("SelfSubjectAccessReviews API result for resource %s group %s : %v\n",
-			kind_plural, apigroup, prettyPrint(result.Status.String()))
+			kindPlural, apigroup, prettyPrint(result.Status.String()))
 		if result.Status.Allowed {
 			return true
 		}

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -161,7 +161,7 @@ func (user *UserDataCache) userHasAllAccess(ctx context.Context, cache *Cache) (
 
 		return true, nil
 	} else if user.userAuthorizedListSSAR(ctx, impersClientSet,
-		"get", "search.open-cluster-management.io", "search.search.open-cluster-management.io/unrestricted") {
+		"get", "search.open-cluster-management.io", "search.search.open-cluster-management.io/allManagedData") {
 		user.csrCache.lock.Lock()
 		defer user.csrCache.lock.Unlock()
 		user.CsResources = []Resource{}

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -153,15 +153,18 @@ func (user *UserDataCache) userHasAllAccess(ctx context.Context, cache *Cache) (
 
 		cache.shared.mcCache.lock.Lock()
 		defer cache.shared.mcCache.lock.Unlock()
-		user.ManagedClusters = cache.shared.managedClusters
+		user.ManagedClusters = map[string]struct{}{"*": {}}
 		user.clustersCache.updatedAt = time.Now()
 		user.csrCache.err, user.nsrCache.err, user.clustersCache.err = nil, nil, nil
+		klog.V(5).Infof("User %s with uid %s has *list* access to all managed cluster resources.",
+			user.userInfo.Username, user.userInfo.UID)
+
 		return true, nil
 	} else if user.userAuthorizedListSSAR(ctx, impersClientSet,
 		"get", "search.open-cluster-management.io", "search.search.open-cluster-management.io/unrestricted") {
 		user.csrCache.lock.Lock()
 		defer user.csrCache.lock.Unlock()
-		user.CsResources = []Resource{{}}
+		user.CsResources = []Resource{}
 		user.csrCache.updatedAt = time.Now()
 
 		user.nsrCache.lock.Lock()
@@ -171,9 +174,11 @@ func (user *UserDataCache) userHasAllAccess(ctx context.Context, cache *Cache) (
 
 		cache.shared.mcCache.lock.Lock()
 		defer cache.shared.mcCache.lock.Unlock()
-		user.ManagedClusters = cache.shared.managedClusters
+		user.ManagedClusters = map[string]struct{}{"*": {}}
 		user.clustersCache.updatedAt = time.Now()
 		user.csrCache.err, user.nsrCache.err, user.clustersCache.err = nil, nil, nil
+		klog.V(5).Infof("User %s with uid %s has *get* access to all managed cluster resources.",
+			user.userInfo.Username, user.userInfo.UID)
 		return true, nil
 	}
 	return false, nil

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -772,7 +772,7 @@ func Test_SearchUserAccessToResources(t *testing.T) {
 			Reason:  "Service account doesn't allow it",
 		},
 	}
-	superUserAccessCheck := &authz.SelfSubjectAccessReview{
+	globalSearchUserAccessCheck := &authz.SelfSubjectAccessReview{
 		Spec: authz.SelfSubjectAccessReviewSpec{},
 		Status: authz.SubjectAccessReviewStatus{
 			Allowed: true,
@@ -792,7 +792,7 @@ func Test_SearchUserAccessToResources(t *testing.T) {
 		case 1:
 			// Second call, return response 2
 			callSequence++
-			return true, superUserAccessCheck, nil
+			return true, globalSearchUserAccessCheck, nil
 		default:
 			// Any subsequent calls, return an error
 			return true, nil, fmt.Errorf("unexpected call")

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -747,7 +747,7 @@ func Test_hasAccessToAllResources(t *testing.T) {
 		t.Errorf("Cache does not have expected cluster-scoped resources ")
 
 	}
-	_, mcPresent := result.ManagedClusters["managed-cluster1"]
+	_, mcPresent := result.ManagedClusters["*"]
 	if len(result.ManagedClusters) != 1 ||
 		!mcPresent {
 		t.Errorf("Cache does not have expected managed cluster resources ")
@@ -758,7 +758,7 @@ func Test_hasAccessToAllResources(t *testing.T) {
 	}
 }
 
-//User should have access to ManagedClusters
+// User should have access to ManagedClusters
 func Test_updateUserManagedClusterList(t *testing.T) {
 	mock_cache := mockNamespaceCache()
 	mock_cache = setupToken(mock_cache)

--- a/pkg/resolver/related.go
+++ b/pkg/resolver/related.go
@@ -289,7 +289,7 @@ func (s *SearchResult) getRelationResolvers(ctx context.Context) []SearchRelated
 		// Convert to format of the relationships resolver []SearchRelatedResult{kind, count, items}
 		relatedSearch = s.searchRelatedResultKindItems(items, resultToCurrSearchUidsMap)
 
-		klog.V(5).Info("RelatedSearch Result: ", relatedSearch)
+		klog.V(6).Info("RelatedSearch Result: ", relatedSearch)
 	} else {
 		klog.Warning("No UIDs matched for relatedKinds: ", pointerToStringArray(s.input.RelatedKinds))
 	}


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-7062

### Description of changes
- Implement the role `searches/allManagedData` which grants the global search user access to all resources from managed clusters.
