### PR TITLE
ACM-7857 Deep copy UserData to avoid concurrency problems

### DIFF
--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -23,6 +23,13 @@ import (
 const impersonationConfigCreationerror = "error creating clientset with impersonation config"
 
 // Contains data about the resources the user is allowed to access.
+type UserData struct {
+	CsResources     []Resource            // Cluster-scoped resources on hub the user has list access.
+	NsResources     map[string][]Resource // Namespaced resources on hub the user has list access.
+	ManagedClusters map[string]struct{}   // Managed clusters where the user has view access.
+}
+
+// Extend UserData with caching information.
 type UserDataCache struct {
 	UserData
 	userInfo authv1.UserInfo
@@ -34,13 +41,6 @@ type UserDataCache struct {
 
 	// Client to external API to be replaced with a mock by unit tests.
 	authzClient v1.AuthorizationV1Interface
-}
-
-// Stuct to keep a copy of users access
-type UserData struct {
-	CsResources     []Resource            // Cluster-scoped resources on hub the user has list access.
-	NsResources     map[string][]Resource // Namespaced resources on hub the user has list access.
-	ManagedClusters map[string]struct{}   // Managed clusters where the user has view access.
 }
 
 // Get user's UID
@@ -197,9 +197,9 @@ func (cache *Cache) GetUserData(ctx context.Context) (UserData, error) {
 	// Proceed if user's rbac data exists
 	// Get a copy of the current user access if user data exists
 	userAccess := UserData{
-		CsResources:     userDataCache.GetCsResources(),
-		NsResources:     userDataCache.GetNsResources(),
-		ManagedClusters: userDataCache.GetManagedClusters(),
+		CsResources:     userDataCache.GetCsResourcesCopy(),
+		NsResources:     userDataCache.GetNsResourcesCopy(),
+		ManagedClusters: userDataCache.GetManagedClustersCopy(),
 	}
 	return userAccess, nil
 }
@@ -474,20 +474,29 @@ func (user *UserDataCache) getImpersonationClientSet() v1.AuthorizationV1Interfa
 	return user.authzClient
 }
 
-func (user *UserDataCache) GetCsResources() []Resource {
+func (user *UserDataCache) GetCsResourcesCopy() []Resource {
 	user.csrCache.lock.Lock()
 	defer user.csrCache.lock.Unlock()
-	return user.CsResources
+	csResourcesCopy := user.CsResources
+	return csResourcesCopy
 }
 
-func (user *UserDataCache) GetNsResources() map[string][]Resource {
+func (user *UserDataCache) GetNsResourcesCopy() map[string][]Resource {
 	user.nsrCache.lock.Lock()
 	defer user.nsrCache.lock.Unlock()
-	return user.NsResources
+	nsResourcesCopy := make(map[string][]Resource)
+	for ns, resources := range user.NsResources {
+		nsResourcesCopy[ns] = resources
+	}
+	return nsResourcesCopy
 }
 
-func (user *UserDataCache) GetManagedClusters() map[string]struct{} {
+func (user *UserDataCache) GetManagedClustersCopy() map[string]struct{} {
 	user.clustersCache.lock.Lock()
 	defer user.clustersCache.lock.Unlock()
-	return user.ManagedClusters
+	mcCopy := make(map[string]struct{})
+	for mc := range user.ManagedClusters {
+		mcCopy[mc] = struct{}{}
+	}
+	return mcCopy
 }

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -583,19 +583,34 @@ func Test_managedCluster_GetUserData(t *testing.T) {
 		UserData:      UserData{ManagedClusters: managedClusters, CsResources: csRes, NsResources: nsRes},
 		clustersCache: cacheMetadata{updatedAt: last_cache_time},
 	}
-	csResResult := mock_cache.users["unique-user-id"].GetCsResources()
+	csResResult := mock_cache.users["unique-user-id"].GetCsResourcesCopy()
 	if len(csResResult) != 2 {
 		t.Errorf("Expected 2 clusterScoped resources but got %d", len(csResResult))
 
 	}
-	nsResResult := mock_cache.users["unique-user-id"].GetNsResources()
+	nsResResult := mock_cache.users["unique-user-id"].GetNsResourcesCopy()
 	if len(nsResResult) != 2 {
 		t.Errorf("Expected 2 namespace Scoped resources but got %d", len(nsResResult))
 	}
-	mcResult := mock_cache.users["unique-user-id"].GetManagedClusters()
+	mcResult := mock_cache.users["unique-user-id"].GetManagedClustersCopy()
 	if len(mcResult) != 1 {
 		t.Errorf("Expected 1 managed cluster but got %d", len(mcResult))
 	}
+
+	// Verify that objects in cache don't change when modifying the object copy.
+	csResResult = append(csResResult, Resource{Kind: "added-by-test", Apigroup: ""}) //nolint
+	if len(csRes) != 2 {
+		t.Errorf("Expected 2 clusterScoped resources but got %d after modifying the object copy.", len(csRes))
+	}
+	nsResResult["ns1"] = append(nsResResult["ns1"], Resource{Kind: "added-by-test", Apigroup: ""})
+	if len(nsRes["ns1"]) != 2 {
+		t.Errorf("Expected 2 namespace Scoped resources but got %d after modifying the object copy.", len(nsRes["ns1"]))
+	}
+	mcResult["added-by-test"] = struct{}{}
+	if len(managedClusters) != 1 {
+		t.Errorf("Expected 1 managed cluster but got %d after modifying the object copy.", len(managedClusters))
+	}
+
 }
 
 func Test_getUserData(t *testing.T) {


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-7857

### Description of changes
- Fixes map concurrency error. UserData had maps that weren't correctly copied and contained references to the objects in the cache. This caused concurrency problems if the cache gets updated while using the copy on UserData.
