### PR TITLE
[release-2.8]  Ignore gosec G602 because of false positive.

### DIFF
--- a/pkg/resolver/searchComplete.go
+++ b/pkg/resolver/searchComplete.go
@@ -219,8 +219,10 @@ func (s *SearchCompleteResult) searchCompleteResults(ctx context.Context) ([]*st
 			})
 			if len(srchCompleteOut) > 1 {
 				// Pass only the min and max values of the numbers to show the range in the UI
+				// Temporarily disable gosec G602, which produces a false positive.
+				// See https://github.com/securego/gosec/issues/1005.
 				srchCompleteOut = append(srchCompleteOutNum, srchCompleteOut[0],
-					srchCompleteOut[len(srchCompleteOut)-1])
+					srchCompleteOut[len(srchCompleteOut)-1]) // #nosec G602
 			} else {
 				srchCompleteOut = append(srchCompleteOutNum, srchCompleteOut...)
 			}


### PR DESCRIPTION

### Related Issue
N/A

### Description of changes
- Ignore gosec G6002 which causes prow build to fail.  The main branch already has this change.
