### PR TITLE
[federation side branch] Fix client pool

### DIFF
--- a/pkg/federated/client.go
+++ b/pkg/federated/client.go
@@ -14,9 +14,7 @@ import (
 // Returns a client to process the federated request.
 func GetHttpClient(remoteService RemoteSearchService) HTTPClient {
 	// Get http client from pool.
-	c := httpClientPool.Get().(*http.Client)
-	// Wrap the client in a RealHTTPClient, this is needed to mock the client in unit tests.
-	client := &RealHTTPClient{c}
+	client := httpClientPool.Get().(*RealHTTPClient)
 
 	tlsConfig := tls.Config{
 		MinVersion: tls.VersionTLS13, // TODO: Verify if 1.3 is ok now. It caused issues in the past.
@@ -56,10 +54,12 @@ var tr = &http.Transport{
 
 var httpClientPool = sync.Pool{
 	New: func() interface{} {
-		klog.Infof(">>> Creating new HTTP client from pool.")
-		return &http.Client{
-			Transport: tr,
-			Timeout:   time.Duration(config.Cfg.HttpPool.RequestTimeout) * time.Millisecond,
+		klog.V(6).Infof("Creating new RealHTTPClient from pool.")
+		return &RealHTTPClient{
+			&http.Client{
+				Transport: tr,
+				Timeout:   time.Duration(config.Cfg.HttpPool.RequestTimeout) * time.Millisecond,
+			},
 		}
 	},
 }


### PR DESCRIPTION
### Related Issue

https://issues.redhat.com/browse/ACM-0000

### Description of changes
Fixes problem using client from the pool.
```
panic: interface conversion: interface {} is *federated.RealHTTPClient, not *http.Client
goroutine 1117 [running]:
github.com/stolostron/search-v2-api/pkg/federated.GetHttpClient({{0x1a1c903, 0xa}, {0x1a4ae75, 0x28}, {0xc000a21600, 0x513}, {0x0, 0x0}, {0x0, 0x0}})
github.com/stolostron/search-v2-api/pkg/federated/client.go:17 +0x374
github.com/stolostron/search-v2-api/pkg/federated.HandleFederatedRequest.func1({{0x1a1c903, 0xa}, {0x1a4ae75, 0x28}, {0xc000a21600, 0x513}, {0x0, 0x0}, {0x0, 0x0}})
github.com/stolostron/search-v2-api/pkg/federated/federated.go:59 +0xd8
created by github.com/stolostron/search-v2-api/pkg/federated.HandleFederatedRequest
github.com/stolostron/search-v2-api/pkg/federated/federated.go:56 +0x40e
```
