### PR TITLE
ACM-8950 return if error while fetching property type

### DIFF
--- a/pkg/resolver/search.go
+++ b/pkg/resolver/search.go
@@ -318,7 +318,7 @@ func WhereClauseFilter(ctx context.Context, input *model.SearchInput,
 				propTypeMapNew, err := getPropertyType(ctx, true) // Refresh the property type cache.
 				if err != nil {
 					klog.Errorf("Error creating property type map with err: [%s] ", err)
-					return whereDs, propTypeMap, fmt.Errorf("error fetching data type for property: [%s]", err)
+					return whereDs, propTypeMap, fmt.Errorf("error [%s] fetching data type for property: [%s]", err, filter.Property)
 				}
 
 				propTypeMap = propTypeMapNew

--- a/pkg/resolver/search.go
+++ b/pkg/resolver/search.go
@@ -313,12 +313,12 @@ func WhereClauseFilter(ctx context.Context, input *model.SearchInput,
 
 			dataType, dataTypeInMap := propTypeMap[filter.Property]
 			if len(propTypeMap) == 0 || !dataTypeInMap {
-				klog.V(3).Info("Property type for [%s] doesn't exist in cache. Refreshing property type cache",
+				klog.V(3).Infof("Property type for [%s] doesn't exist in cache. Refreshing property type cache",
 					filter.Property)
 				propTypeMapNew, err := getPropertyType(ctx, true) // Refresh the property type cache.
 				if err != nil {
 					klog.Errorf("Error creating property type map with err: [%s] ", err)
-					break
+					return whereDs, propTypeMap, fmt.Errorf("error fetching data type for property: [%s]", err)
 				}
 
 				propTypeMap = propTypeMapNew


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-8950

### Description of changes
- Return if error while fetching property type

Return as soon as error occurs:
```
E1207 13:46:05.894476       1 sharedData.go:87] Error resolving property types query [SELECT DISTINCT key, jsonb_typeof("value") AS "datatype" FROM "search"."resources", jsonb_each("data")] with args [context canceled]. Error: [%!v(MISSING)]
E1207 13:46:05.894488       1 sharedData.go:127] Error retrieving property types. Error: [context canceled]
E1207 13:46:05.894554       1 search.go:308] Error creating property type map with err: [context canceled] 
runtime error: invalid memory address or nil pointer dereference
```


