### PR TITLE
ACM-9302: Update federated search setup and cleanup scripts

### DIFF
--- a/pkg/federated/README.md
+++ b/pkg/federated/README.md
@@ -8,7 +8,11 @@ Use federated search to query and combine results from multiple Red Hat Advanced
     - Managed Hub clusters mu have RHACM 2.9.0 or later
 
 ## Setup
-Execute the script at `./setup.sh` to configure Global Search on the Global Hub cluster.  
+Execute the script at `./setup.sh` to configure Global Search on the Global Hub cluster. 
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/stolostron/search-v2-api/main/pkg/federated/setup.sh) 
+``` 
 
 The script automates the following steps:
   1. Enable the Managed Service Account add-on in the MulticlusterEngine CR.
@@ -20,3 +24,10 @@ The script automates the following steps:
 > Must run using an account with role `open-cluster-management:admin-aggregate` or higher.
 > You must re-run this script when a Managed Hub is added.    
 > This setup is required for Development Preview, it will be fully automated for GA.
+
+## Uninstall
+Execute the script at `./cleanup.sh` to remove the Global Search configuration from the Global Hub cluster. 
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/stolostron/search-v2-api/main/pkg/federated/cleanup.sh) 
+``` 

--- a/pkg/federated/cleanup.sh
+++ b/pkg/federated/cleanup.sh
@@ -5,7 +5,68 @@
 MANAGED_HUBS=($(oc get managedcluster -o json | jq -r '.items[] | select(.status.clusterClaims[] | .name == "hub.open-cluster-management.io" and .value != "NotInstalled") | .metadata.name'))
 
 for MANAGED_HUB in "${MANAGED_HUBS[@]}"; do
-  oc delete -n ${MANAGED_HUB} -f ./federation-managed-hub-config.yaml
+  # NOTE: The YAML file is added in-line below to simplify deployment with a single script file.
+  #       Any changes below must be synchronized with the setup.sh script.
+  # oc delete -n ${MANAGED_HUB} -f ./federation-managed-hub-config.yaml
+  oc delete -n "${MANAGED_HUB}" -f - << EOF
+apiVersion: work.open-cluster-management.io/v1
+kind: ManifestWork
+metadata:
+  labels:
+    app: ocm-search
+  name: search-global-config
+spec:
+  workload:
+    manifests:
+    - apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        labels:
+          app: ocm-search
+        name: search-global-binding
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: global-search-user
+      subjects:
+      - kind: ServiceAccount
+        name: search-global
+        namespace: open-cluster-management-agent-addon
+    - apiVersion: route.openshift.io/v1
+      kind: Route
+      metadata:
+        labels:
+          app: ocm-search
+        name: search-global-hub
+        namespace: open-cluster-management
+      spec:
+        port:
+          targetPort: search-api
+        tls:
+          termination: passthrough
+        to:
+          kind: Service
+          name: search-search-api
+          weight: 100
+---
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: managed-serviceaccount
+  labels:
+    app: ocm-search
+spec:
+  installNamespace: open-cluster-management-agent-addon
+---
+apiVersion: authentication.open-cluster-management.io/v1beta1
+kind: ManagedServiceAccount
+metadata:
+  name: search-global
+  labels:
+    app: ocm-search
+spec:
+  rotation: {}
+EOF
 done 
 
 # Disable global search feature in the console.
@@ -14,3 +75,18 @@ oc patch configmap console-config -n open-cluster-management -p '{"data": {"glob
 
 # Disable federated search feature in the search-api.
 oc patch search search-v2-operator -n open-cluster-management --type='merge' -p '{"spec":{"deployments":{"queryapi":{"envVar":[{"name":"FEATURE_FEDERATED_SEARCH", "value":"false"}]}}}}'
+
+# Disable the ManagedServiceAccount feature in multicluster-engine.
+# First check if there are any instances of the ManagedServiceAccount resource.
+if oc get managedserviceaccount --all-namespaces --no-headers; then
+  echo ""
+  echo "Found instances of ManagedServiceAccount resource. This script won't disable the Managed Service Account feature because it appears to be in use."
+  echo "Please review the use of ManagedServiceAccount and, if needed, disable it manually using the following patch command:"
+  echo ""
+  echo "oc patch multiclusterengine multiclusterengine --type='json' -p='[{\"op\": \"add\", \"path\": \"/spec/overrides/components\", \"value\": [{\"name\": \"managedserviceaccount\", \"enabled\": false}]}]'"
+else
+  oc patch multiclusterengine multiclusterengine --type='json' -p='[{"op": "add", "path": "/spec/overrides/components", "value": [{"name": "managedserviceaccount", "enabled": false}]}]'
+  echo "Disabled the Managed Service Account add-on in MulticlusterEngine."
+  echo "✅ Global Search feature has been disabled and resources have been deleted." 
+fi
+


### PR DESCRIPTION
### Related Issue

https://issues.redhat.com/browse/ACM-9302

### Description of changes
- Simplify usage of setup.sh and cleanup.sh scripts by including the yaml templates inline.
- Improve cleanup.sh to check if ManagedServiceAccount is being used in the cluster before disabling.
- Update README.md
