### PR TITLE
[ACM-14996] Fix Messages query to get disabled clusters

### DIFF
--- a/pkg/rbac/sharedData.go
+++ b/pkg/rbac/sharedData.go
@@ -359,10 +359,21 @@ func (cache *Cache) GetDisabledClusters(ctx context.Context) (*map[string]struct
 func disabledClustersForUser(disabledClusters map[string]struct{},
 	userClusters map[string]struct{}, uid string) map[string]struct{} {
 	userAccessDisabledClusters := map[string]struct{}{}
-	for disabledCluster := range disabledClusters {
-		if _, userHasAccess := userClusters[disabledCluster]; userHasAccess { //user has access
-			klog.V(7).Info("user ", uid, " has access to search addon disabled cluster: ", disabledCluster)
-			userAccessDisabledClusters[disabledCluster] = struct{}{}
+
+	var userClustersKeys []string
+	for k := range userClusters {
+		userClustersKeys = append(userClustersKeys, k)
+	}
+
+	if len(userClusters) == 1 && userClustersKeys[0] == "*" {
+		klog.V(5).Info("User has access to all clusters - returning the disabled cluster list.")
+		return disabledClusters
+	} else {
+		for disabledCluster := range disabledClusters {
+			if _, userHasAccess := userClusters[disabledCluster]; userHasAccess { //user has access
+				klog.V(7).Info("user ", uid, " has access to search addon disabled cluster: ", disabledCluster)
+				userAccessDisabledClusters[disabledCluster] = struct{}{}
+			}
 		}
 	}
 	return userAccessDisabledClusters


### PR DESCRIPTION
### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-14996

### Description of changes
- Messages query was not properly handling the ManagedCluster array when the user has access to all Resources (userData.ManagedClusters = map[*:{}])
