### PR TITLE
Add support for integer values in map properties

### DIFF
--- a/pkg/resolver/searchHelper_test.go
+++ b/pkg/resolver/searchHelper_test.go
@@ -1,0 +1,33 @@
+package resolver
+
+import "testing"
+
+func Test_formatMapIntegers(t *testing.T) {
+	policyViolationCounts := map[string]interface{}{
+		"namespace/policy1": float64(2),
+		"clusterpolicy2":    float64(1),
+	}
+
+	expected := "clusterpolicy2=1; namespace/policy1=2"
+
+	rv := formatMap(policyViolationCounts)
+
+	if rv != expected {
+		t.Fatalf("Expected %s but got: %s", expected, rv)
+	}
+}
+
+func Test_formatMapStrings(t *testing.T) {
+	labels := map[string]interface{}{
+		"hello": "world",
+		"city":  "raleigh",
+	}
+
+	expected := "city=raleigh; hello=world"
+
+	rv := formatMap(labels)
+
+	if rv != expected {
+		t.Fatalf("Expected %s but got: %s", expected, rv)
+	}
+}


### PR DESCRIPTION
This is helpful to have a mapping of keys to counts. By keeping it as a number in the database instead of converting it as part of the indexing, it allows formatting it differently in the future.

This is required by https://github.com/stolostron/search-collector/pull/327.

Relates:
https://issues.redhat.com/browse/ACM-15127
