### PR TITLE
Fix gosec errors converting to uint

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,7 +39,7 @@ type Config struct {
 	HttpPort            int
 	PlaygroundMode      bool   // Enable the GraphQL Playground client.
 	PodNamespace        string // Kubernetes namespace where the pod is running.
-	QueryLimit          int    // The default LIMIT to use on queries. Client can override.
+	QueryLimit          uint   // The default LIMIT to use on queries. Client can override.
 	RelationLevel       int    // The number of levels/hops for finding relationships for a particular resource
 	SlowLog             int    // Logs when queries are slower than the specified time duration in ms. Default 300ms
 }
@@ -106,7 +106,7 @@ func new() *Config {
 		HttpPort:       getEnvAsInt("HTTP_PORT", 4010),
 		PlaygroundMode: getEnvAsBool("PLAYGROUND_MODE", false),
 		PodNamespace:   getEnv("POD_NAMESPACE", "open-cluster-management"),
-		QueryLimit:     getEnvAsInt("QUERY_LIMIT", 1000),
+		QueryLimit:     getEnvAsUint("QUERY_LIMIT", uint(1000)),
 		SlowLog:        getEnvAsInt("SLOW_LOG", 300),
 		// Setting default level to 0 to check if user has explicitly set this variable
 		// This will be updated to 1 for default searches and 3 for applications - unless set by the user
@@ -158,6 +158,15 @@ func getEnvAsInt(name string, defaultVal int) int {
 	valueStr := getEnv(name, "")
 	if value, err := strconv.Atoi(valueStr); err == nil {
 		return value
+	}
+	return defaultVal
+}
+
+// Helper function to read an environment variable into unsigned integer or return a default value
+func getEnvAsUint(name string, defaultVal uint) uint {
+	valueStr := getEnv(name, "")
+	if value, err := strconv.ParseUint(valueStr, 10, 32); err == nil {
+		return uint(value)
 	}
 	return defaultVal
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,11 +24,11 @@ type Config struct {
 	UserCacheTTL        int    // Time-to-live (milliseconds) of namespaced resources (specifc to users) cache.
 	ContextPath         string
 	DBHost              string
-	DBMinConns          int // Overrides pgxpool.Config{ MinConns } Default: 0
-	DBMaxConns          int // Overrides pgxpool.Config{ MaxConns } Default: 10
-	DBMaxConnIdleTime   int // Overrides pgxpool.Config{ MaxConnIdleTime } Default: 30 min
-	DBMaxConnLifeTime   int // Overrides pgxpool.Config{ MaxConnLifetime } Default: 60 min
-	DBMaxConnLifeJitter int // Overrides pgxpool.Config{ MaxConnLifetimeJitter } Default: 2 min
+	DBMinConns          int32 // Overrides pgxpool.Config{ MinConns } Default: 0
+	DBMaxConns          int32 // Overrides pgxpool.Config{ MaxConns } Default: 10
+	DBMaxConnIdleTime   int   // Overrides pgxpool.Config{ MaxConnIdleTime } Default: 30 min
+	DBMaxConnLifeTime   int   // Overrides pgxpool.Config{ MaxConnLifetime } Default: 60 min
+	DBMaxConnLifeJitter int   // Overrides pgxpool.Config{ MaxConnLifetimeJitter } Default: 2 min
 	DBName              string
 	DBPass              string
 	DBPort              int
@@ -158,6 +158,15 @@ func getEnvAsInt(name string, defaultVal int) int {
 	valueStr := getEnv(name, "")
 	if value, err := strconv.Atoi(valueStr); err == nil {
 		return value
+	}
+	return defaultVal
+}
+
+// Helper function to read an environment variable into integer32 or return a default value
+func getEnvAsInt32(name string, defaultVal int32) int32 {
+	valueStr := getEnv(name, "")
+	if value, err := strconv.ParseInt(valueStr, 10, 32); err == nil {
+		return int32(value)
 	}
 	return defaultVal
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,11 +78,11 @@ func new() *Config {
 		ContextPath:    getEnv("CONTEXT_PATH", "/searchapi"),
 		DBHost:         getEnv("DB_HOST", "localhost"),
 		// Postgres has 100 conns by default. Using 20 allows scaling indexer and api.
-		DBMaxConns:          getEnvAsInt("DB_MAX_CONNS", 10),                   // 10 - Overrides pgxpool default
+		DBMaxConns:          getEnvAsInt32("DB_MAX_CONNS", int32(10)),          // 10 - Overrides pgxpool default
 		DBMaxConnIdleTime:   getEnvAsInt("DB_MAX_CONN_IDLE_TIME", 30*60*1000),  // 30 min - Default for pgxpool.Config
 		DBMaxConnLifeJitter: getEnvAsInt("DB_MAX_CONN_LIFE_JITTER", 2*60*1000), // 2 min - Overrides pgxpool default
 		DBMaxConnLifeTime:   getEnvAsInt("DB_MAX_CONN_LIFE_TIME", 60*60*1000),  // 60 min - Default for pgxpool.Config
-		DBMinConns:          getEnvAsInt("DB_MIN_CONNS", 0),                    // Default for pgxpool.Config
+		DBMinConns:          getEnvAsInt32("DB_MIN_CONNS", int32(0)),           // Default for pgxpool.Config
 		DBName:              getEnv("DB_NAME", ""),
 		DBPass:              getEnv("DB_PASS", ""),
 		DBPort:              getEnvAsInt("DB_PORT", 5432),

--- a/pkg/resolver/search.go
+++ b/pkg/resolver/search.go
@@ -171,7 +171,7 @@ func buildRbacWhereClause(ctx context.Context, userrbac rbac.UserData, userInfo 
 // Example query: SELECT uid, cluster, data FROM search.resources  WHERE lower(data->> 'kind') IN
 // (lower('Pod')) AND lower(data->> 'cluster') IN (lower('local-cluster')) LIMIT 1000
 func (s *SearchResult) buildSearchQuery(ctx context.Context, count bool, uid bool) error {
-	var limit int
+	var limit uint
 	var selectDs *goqu.SelectDataset
 	var whereDs []exp.Expression
 	var params []interface{}
@@ -239,7 +239,7 @@ func (s *SearchResult) buildSearchQuery(ctx context.Context, count bool, uid boo
 
 	// Get the query
 	if limit != 0 {
-		sql, params, err = selectDs.Where(whereDs...).Limit(uint(limit)).ToSQL()
+		sql, params, err = selectDs.Where(whereDs...).Limit(limit).ToSQL()
 	} else {
 		sql, params, err = selectDs.Where(whereDs...).ToSQL()
 	}

--- a/pkg/resolver/searchComplete.go
+++ b/pkg/resolver/searchComplete.go
@@ -77,7 +77,7 @@ func SearchComplete(ctx context.Context, property string, srchInput *model.Searc
 // ORDER BY name ASC
 // LIMIT 1000
 func (s *SearchCompleteResult) searchCompleteQuery(ctx context.Context) {
-	var limit int
+	var limit uint
 	var whereDs []exp.Expression
 	var selectDs *goqu.SelectDataset
 
@@ -124,7 +124,7 @@ func (s *SearchCompleteResult) searchCompleteQuery(ctx context.Context) {
 
 		// LIMIT CLAUSE
 		if s.limit != nil && *s.limit > 0 {
-			limit = *s.limit
+			limit = uint(*s.limit)
 		} else if s.limit != nil && *s.limit == -1 {
 			klog.Warning("Limit set to -1. Fetching all results. This may affect performance.")
 		} else {
@@ -137,7 +137,7 @@ func (s *SearchCompleteResult) searchCompleteQuery(ctx context.Context) {
 
 		// Get the query
 		if limit > 0 {
-			sql, params, err = selectDs.Where(whereDs...).Limit(uint(limit)).ToSQL()
+			sql, params, err = selectDs.Where(whereDs...).Limit(limit).ToSQL()
 		} else {
 			sql, params, err = selectDs.Where(whereDs...).ToSQL()
 		}

--- a/pkg/resolver/searchHelper.go
+++ b/pkg/resolver/searchHelper.go
@@ -441,7 +441,7 @@ func (s *SearchResult) setLimit() uint {
 	var limit uint
 	if s.input != nil && s.input.Limit != nil && *s.input.Limit > 0 {
 		if *s.input.Limit <= math.MaxUint32 {
-			limit = uint(*s.input.Limit)
+			limit = uint(*s.input.Limit) // #nosec G115
 		} else {
 			limit = math.MaxUint32
 		}

--- a/pkg/resolver/searchHelper.go
+++ b/pkg/resolver/searchHelper.go
@@ -436,10 +436,10 @@ func getKeys(stringKeyMap interface{}) []string {
 }
 
 // Set limit for queries
-func (s *SearchResult) setLimit() int {
-	var limit int
+func (s *SearchResult) setLimit() uint {
+	var limit uint
 	if s.input != nil && s.input.Limit != nil && *s.input.Limit > 0 {
-		limit = *s.input.Limit
+		limit = uint(*s.input.Limit)
 	} else if s.input != nil && s.input.Limit != nil && *s.input.Limit == -1 {
 		klog.V(2).Info("No limit set on query. Fetching all results.")
 	} else {

--- a/pkg/resolver/searchHelper.go
+++ b/pkg/resolver/searchHelper.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"regexp"
 	"sort"
@@ -439,7 +440,11 @@ func getKeys(stringKeyMap interface{}) []string {
 func (s *SearchResult) setLimit() uint {
 	var limit uint
 	if s.input != nil && s.input.Limit != nil && *s.input.Limit > 0 {
-		limit = uint(*s.input.Limit)
+		if *s.input.Limit <= math.MaxUint32 {
+			limit = uint(*s.input.Limit)
+		} else {
+			limit = math.MaxUint32
+		}
 	} else if s.input != nil && s.input.Limit != nil && *s.input.Limit == -1 {
 		klog.V(2).Info("No limit set on query. Fetching all results.")
 	} else {

--- a/pkg/resolver/searchSchema.go
+++ b/pkg/resolver/searchSchema.go
@@ -78,10 +78,10 @@ func (s *SearchSchema) buildSearchSchemaQuery(ctx context.Context) {
 	// Adding a high number so as to get almost all the distinct properties from the database
 	if whereDs != nil {
 		selectDs = ds.SelectDistinct("prop").From(ds.Select(jsb).Where(whereDs).
-			Limit(uint(config.Cfg.QueryLimit) * 100).As("schema"))
+			Limit(config.Cfg.QueryLimit * 100).As("schema"))
 	} else {
 		selectDs = ds.SelectDistinct("prop").From(ds.Select(jsb).
-			Limit(uint(config.Cfg.QueryLimit) * 100).As("schema"))
+			Limit(config.Cfg.QueryLimit * 100).As("schema"))
 	}
 	//Get the query
 	sql, params, err := selectDs.ToSQL()


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- Change  limit to `uint` to fix gosec warnings.
