### PR TITLE
ACM-16126: Fix incorrect apigroup on managedclusterview check

### DIFF
--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -363,7 +363,7 @@ func (user *UserDataCache) getSSRRforNamespace(ctx context.Context, cache *Cache
 			// Equivalent to: oc auth can-i create ManagedClusterView -n <managedClusterName> --as=<user>
 			if verb == "create" || verb == "*" {
 				for _, group := range rule.APIGroups {
-					if group == "cluster.open-cluster-management.io" || group == "*" {
+					if group == "view.open-cluster-management.io" || group == "*" {
 						for _, res := range rule.Resources {
 							if res == "managedclusterviews" || res == "*" {
 								user.updateUserManagedClusterList(cache, ns)

--- a/pkg/rbac/userData_test.go
+++ b/pkg/rbac/userData_test.go
@@ -384,7 +384,7 @@ func Test_managedClusters_emptyCache(t *testing.T) {
 			ResourceRules: []authz.ResourceRule{
 				{
 					Verbs:     []string{"create"},
-					APIGroups: []string{"cluster.open-cluster-management.io"},
+					APIGroups: []string{"view.open-cluster-management.io"},
 					Resources: []string{"managedclusterviews"},
 				},
 			},
@@ -398,7 +398,7 @@ func Test_managedClusters_emptyCache(t *testing.T) {
 			ResourceRules: []authz.ResourceRule{
 				{
 					Verbs:     []string{"list"},
-					APIGroups: []string{"cluster.open-cluster-management.io"},
+					APIGroups: []string{"view.open-cluster-management.io"},
 					Resources: []string{"managedclusterviews"},
 				},
 			},
@@ -497,7 +497,7 @@ func Test_managedCluster_expiredCache(t *testing.T) {
 			ResourceRules: []authz.ResourceRule{
 				{
 					Verbs:     []string{"create"},
-					APIGroups: []string{"cluster.open-cluster-management.io"},
+					APIGroups: []string{"view.open-cluster-management.io"},
 					Resources: []string{"managedclusterviews"},
 				},
 			},
@@ -511,7 +511,7 @@ func Test_managedCluster_expiredCache(t *testing.T) {
 			ResourceRules: []authz.ResourceRule{
 				{
 					Verbs:     []string{"list"},
-					APIGroups: []string{"cluster.open-cluster-management.io"},
+					APIGroups: []string{"view.open-cluster-management.io"},
 					Resources: []string{"managedclusterviews"},
 				},
 			},


### PR DESCRIPTION
### Related Issue
https://issues.redhat.com/browse/ACM-16126

### Description of changes
- The rbac check for managedclusterview was using the incorrect apigroup.
- Updated to use `view.open-cluster-management.io/v1beta1`

```bash
$ oc api-resources |grep managedclusterview
managedclusterviews       view.open-cluster-management.io/v1beta1       true      ManagedClusterView
```