### PR TITLE
fix sast-coverity-check-oci-ta by adding missing image-digest

### DIFF
--- a/.tekton/search-v2-api-acm-214-pull-request.yaml
+++ b/.tekton/search-v2-api-acm-214-pull-request.yaml
@@ -463,6 +463,8 @@ spec:
           value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2@sha256:07cb09253da53235f83d1a2327faebb8505091c509fc1e3af12a43cfe34f63a6
         - name: kind
           value: task
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         resolver: bundles
       when:
       - input: $(params.skip-checks)


### PR DESCRIPTION
### Description of changes
- Added image-digest param to sast-coverity-check-oci-ta to fix https://github.com/stolostron/search-v2-api/pull/444