### PR TITLE
ACM-21036 return no results instead of err when vm has no snapshots

### DIFF
--- a/pkg/resolver/search.go
+++ b/pkg/resolver/search.go
@@ -372,7 +372,7 @@ func WhereClauseFilter(ctx context.Context, input *model.SearchInput,
 				propTypeMapNew, err := getPropertyType(ctx, true) // Refresh the property type cache.
 				propTypeMap = propTypeMapNew
 				dataType, dataTypeInMap = propTypeMap[filter.Property]
-				klog.V(1).Infof("For filter prop: %s, datatype is :%s dataTypeInMap: %t\n", filter.Property,
+				klog.V(3).Infof("For filter prop: %s, datatype is :%s dataTypeInMap: %t\n", filter.Property,
 					dataType, dataTypeInMap)
 				if err != nil {
 					klog.Errorf("Error creating property type map with err: [%s]", err)


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-21036 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-21036

### Description of changes
- Added one-time filter 1 = 0 when an input filter property does not exist instead of err. The end result is that no results should be returned to the user. I'm choosing to add this condition and let the request continue and execute the SQL because I believe the runtime to be negligent enough that it's worth doing over adding the code returning a flag to be checked in buildSearchQuery, searchCompleteQuery, and buildSearchSchemaQuery. Especially since this so far appears to be a niche case that has only been identified in the VM snapshots tab.