### PR TITLE
ACM-22418 Remove sub-resources from RBAC filter

### DIFF
--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -344,6 +345,10 @@ func (user *UserDataCache) getSSRRforNamespace(ctx context.Context, cache *Cache
 		for _, verb := range rule.Verbs {
 			if verb == "list" || verb == "*" {
 				for _, res := range rule.Resources {
+					// Skip sub-resources. Database only has resources, not sub-resources
+					if strings.Contains(res, "/") {
+						continue
+					}
 					for _, api := range rule.APIGroups {
 						// Add the resource if it is not cluster scoped
 						// fail-safe mechanism to avoid whitelist - TODO: incorporate whitelist
@@ -362,7 +367,11 @@ func (user *UserDataCache) getSSRRforNamespace(ctx context.Context, cache *Cache
 								return
 							}
 							currRes := Resource{Apigroup: api, Kind: res}
-							//to avoid duplicates, check before appending to nsResources
+							// Skip sub-resources. Database only has resources, not sub-resources
+							// if strings.Contains(currRes.Kind, "/") {
+							// 	continue
+							// }
+							// to avoid duplicates, check before appending to nsResources
 							if _, found := trackResources[currRes]; !found {
 								user.NsResources[ns] = append(user.NsResources[ns], currRes)
 								trackResources[currRes] = struct{}{}


### PR DESCRIPTION
### Related Issue

https://issues.redhat.com/browse/ACM-22418

### Description of changes
- Discard subresources like pods/logs when building the RBAC filter. The search database only contains resources.
