### PR TITLE
Add repository url label to container images

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -19,6 +19,7 @@ USER ${USER_UID}
 ENTRYPOINT ["/bin/main"]
 
 LABEL com.redhat.component="acm-search-api-container" \
+      url="https://github.com/stolostron/search-v2-api" \
       description="Search api service" \      
       maintainer="acm-contact@redhat.com" \
       name="search-api" \


### PR DESCRIPTION
This pull request adds the repository URL as the 'url' label to container images.

**Related Issue:** https://issues.redhat.com/browse/ACM-23275

**Epic Goal:** All ACM and MCE container images should define the url label pointing to their source repository instead of the generic 'https://www.redhat.com' value.

**Target Branch:** release-2.15

**Components affected:** search-v2-api

**Branch details:** search-v2-api (branch: release-2.15)

**Label added:**
- url: https://github.com/stolostron/search-v2-api

This change improves traceability and helps identify the source repository for each container image, which is especially important for components like kube-rbac-proxy that exist in multiple organizations.