### PR TITLE
Remove token from websocket connection_ack

### DIFF
--- a/pkg/server/websocket.go
+++ b/pkg/server/websocket.go
@@ -98,7 +98,8 @@ func WebSocketInitFunc() func(context.Context, transport.InitPayload) (context.C
 		ctx = context.WithValue(ctx, rbac.ContextAuthTokenKey, authToken)
 
 		// Return the modified context and payload
-		return ctx, &initPayload, nil
+		returnPayload := transport.InitPayload{}
+		return ctx, &returnPayload, nil
 	}
 }
 


### PR DESCRIPTION
### Related Issue
N/A

### Description of changes
- Removes the token from the `connection_ack` payload.
<img width="640" height="75" alt="image" src="https://github.com/user-attachments/assets/93ddad0e-38d9-4253-9f8c-6aa25191b38d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket initialization payload handling to ensure proper object lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->