### PR TITLE
Add dedicated cache TTL for UserPermissions

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,10 +19,11 @@ var Cfg = new()
 type Config struct {
 	HubName             string //Display Name of the cluster where ACM is deployed
 	API_SERVER_URL      string // address for Kubernetes API Server
-	AuthCacheTTL        int    // Time-to-live (milliseconds) of Authentication (TokenReview) cache.
-	SharedCacheTTL      int    // Time-to-live (milliseconds) of common resources (shared across users) cache.
-	UserCacheTTL        int    // Time-to-live (milliseconds) of namespaced resources (specifc to users) cache.
-	ContextPath         string
+	AuthCacheTTL            int    // Time-to-live (milliseconds) of Authentication (TokenReview) cache.
+	SharedCacheTTL          int    // Time-to-live (milliseconds) of common resources (shared across users) cache.
+	UserCacheTTL            int    // Time-to-live (milliseconds) of namespaced resources (specifc to users) cache.
+	UserPermissionCacheTTL  int    // Time-to-live (milliseconds) of UserPermissions cache. Default: 30 seconds
+	ContextPath             string
 	DBHost              string
 	DBMinConns          int32 // Overrides pgxpool.Config{ MinConns } Default: 2
 	DBMaxConns          int32 // Overrides pgxpool.Config{ MaxConns } Default: 10
@@ -76,10 +77,11 @@ func new() *Config {
 	conf := &Config{
 		HubName:             getEnv("HUB_NAME", "global-hub"),
 		API_SERVER_URL:      getEnv("API_SERVER_URL", "https://kubernetes.default.svc"),
-		AuthCacheTTL:        getEnvAsInt("AUTH_CACHE_TTL", 60000),    // 1 minute
-		SharedCacheTTL:      getEnvAsInt("SHARED_CACHE_TTL", 300000), // 5 minutes
-		UserCacheTTL:        getEnvAsInt("USER_CACHE_TTL", 300000),   // 5 minutes
-		ContextPath:         getEnv("CONTEXT_PATH", "/searchapi"),
+		AuthCacheTTL:           getEnvAsInt("AUTH_CACHE_TTL", 60000),              // 1 minute
+		SharedCacheTTL:         getEnvAsInt("SHARED_CACHE_TTL", 300000),           // 5 minutes
+		UserCacheTTL:           getEnvAsInt("USER_CACHE_TTL", 300000),             // 5 minutes
+		UserPermissionCacheTTL: getEnvAsInt("USER_PERMISSION_CACHE_TTL", 30000),   // 30 seconds
+		ContextPath:            getEnv("CONTEXT_PATH", "/searchapi"),
 		DBHost:              getEnv("DB_HOST", "localhost"),
 		DBMaxConns:          getEnvAsInt32("DB_MAX_CONNS", int32(10)),          // 10     Overrides pgxpool default (4)
 		DBMaxConnIdleTime:   getEnvAsInt("DB_MAX_CONN_IDLE_TIME", 5*60*1000),   // 5 min, Overrides pgxpool default (30)

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -222,9 +222,10 @@ func (cache *Cache) GetUserData(ctx context.Context) (UserData, error) {
 		return UserData{}, errors.New("unable to resolve query because of error while resolving user's access")
 	}
 
-	// Ensure UserPermissions cache is fresh before using it for RBAC filtering.
+	// Ensure UserPermissions cache is fresh before using it for fine-grained RBAC filtering.
 	// This is critical for search/searchComplete/searchSchema which use buildRbacWhereClause.
-	if len(userDataCache.UserPermissions.Items) == 0 || !userDataCache.userPermissionCache.isValid() {
+	if config.Cfg.Features.FineGrainedRbac &&
+		(len(userDataCache.UserPermissions.Items) == 0 || !userDataCache.userPermissionCache.isValid()) {
 		if err := userDataCache.getUserPermissions(ctx); err != nil {
 			klog.Error("Error refreshing UserPermissions: ", err)
 			return UserData{}, errors.New("unable to resolve query because of error while refreshing user permissions")

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -111,7 +111,7 @@ func (cache *Cache) GetUserDataCache(ctx context.Context,
 			clustersCache:       cacheMetadata{ttl: time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond},
 			csrCache:            cacheMetadata{ttl: time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond},
 			nsrCache:            cacheMetadata{ttl: time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond},
-			userPermissionCache: cacheMetadata{ttl: time.Duration(config.Cfg.UserCacheTTL) * time.Millisecond},
+			userPermissionCache: cacheMetadata{ttl: time.Duration(config.Cfg.UserPermissionCacheTTL) * time.Millisecond},
 		}
 		if cache.users == nil {
 			cache.users = map[string]*UserDataCache{}
@@ -233,12 +233,10 @@ func (cache *Cache) GetUserData(ctx context.Context) (UserData, error) {
 	return userAccess, nil
 }
 
-// UserCache is valid if the clustersCache, csrCache, fgRbacNsCache, and nsrCache are valid.
+// UserCache is valid if the clustersCache, csrCache, and nsrCache are valid.
+// Note: userPermissionCache is validated separately where it's used (CheckUserHasAccess)
+// to allow independent TTL control.
 func (user *UserDataCache) isValid() bool {
-	if config.Cfg.Features.FineGrainedRbac {
-		return user.csrCache.isValid() && user.nsrCache.isValid() &&
-			user.clustersCache.isValid() && user.userPermissionCache.isValid()
-	}
 	return user.csrCache.isValid() && user.nsrCache.isValid() &&
 		user.clustersCache.isValid()
 }

--- a/pkg/rbac/userData.go
+++ b/pkg/rbac/userData.go
@@ -221,6 +221,16 @@ func (cache *Cache) GetUserData(ctx context.Context) (UserData, error) {
 		klog.Error("Error fetching UserAccessData: ", userDataErr)
 		return UserData{}, errors.New("unable to resolve query because of error while resolving user's access")
 	}
+
+	// Ensure UserPermissions cache is fresh before using it for RBAC filtering.
+	// This is critical for search/searchComplete/searchSchema which use buildRbacWhereClause.
+	if len(userDataCache.UserPermissions.Items) == 0 || !userDataCache.userPermissionCache.isValid() {
+		if err := userDataCache.getUserPermissions(ctx); err != nil {
+			klog.Error("Error refreshing UserPermissions: ", err)
+			return UserData{}, errors.New("unable to resolve query because of error while refreshing user permissions")
+		}
+	}
+
 	// Proceed if user's rbac data exists
 	// Get a copy of the current user access if user data exists
 	userAccess := UserData{


### PR DESCRIPTION
## Summary
Decouples UserPermissions cache from other user caches to reduce RBAC permission propagation delay from **5 minutes to 30 seconds**.

Fixes: ACM-26935

## Problem
When RBAC permissions are added for a user, the CNV VM page and ACM search VM page take 2-5 minutes to show the expected results. This is caused by the UserPermissions cache sharing the same 5-minute TTL with clusters, CSR, and NSR caches.

## Solution
- Add new `UserPermissionCacheTTL` config (default: 30 seconds, configurable via `USER_PERMISSION_CACHE_TTL` env var)
- Keep `UserCacheTTL` at 5 minutes for clusters/CSR/NSR (less volatile resources)
- Remove `userPermissionCache.isValid()` from main cache validity check to prevent invalidating all caches after 30 seconds

## Changes
### pkg/config/config.go
- Added `UserPermissionCacheTTL int` field with default 30000 ms

### pkg/rbac/userData.go
- Line 114: Updated `userPermissionCache` to use `UserPermissionCacheTTL`
- Line 237-243: Removed `userPermissionCache.isValid()` from main `isValid()` check
  - UserPermissions is validated separately where it's used (line 588)
  - Prevents 30-second TTL from invalidating all caches

## Impact
✅ Reduces permission propagation delay from 5 minutes to 30 seconds  
✅ Minimal performance impact (UserPermissions API is lightweight)  
✅ Backward compatible (other caches maintain 5-minute TTL)  
✅ Prevents unnecessary refetching of clusters/CSR/NSR every 30 seconds  

## Testing
- All tests pass ✅
- Linter shows 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configuration option to set user-permission cache TTL independently (default 30s).
  * Permission-cache validation is now handled separately from overall user-data cache.

* **Bug Fixes**
  * User permissions are refreshed when missing or expired to ensure up-to-date access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->