### PR TITLE
Fixes subscription e2e tests failing and problem with multiple ws connections

### DIFF
--- a/pkg/database/listener.go
+++ b/pkg/database/listener.go
@@ -332,9 +332,16 @@ func (l *Listener) forwardNotification(notification *pgconn.Notification) {
 
 	klog.V(3).Infof("Received postgres event, forwarding to %d subscriptions.", len(l.subscriptions))
 	for _, sub := range l.subscriptions {
+		// Check Done first (without competing with the send case) to guarantee
+		// cancelled subscriptions are skipped even when the channel has space.
 		select {
 		case <-sub.Context.Done():
 			klog.V(3).Infof("Subscription %s context is done, skipping", sub.ID)
+			continue
+		default:
+		}
+		// Non-blocking send: drop the event if the channel buffer is full.
+		select {
 		case sub.Channel <- &notificationPayload:
 		default:
 			klog.Warningf("Subscription %s channel buffer is full, dropping event.", sub.ID)

--- a/pkg/database/listener.go
+++ b/pkg/database/listener.go
@@ -269,63 +269,75 @@ func (l *Listener) listen() {
 			}
 
 			if notification != nil {
-				l.mu.RLock()
-				// Ensure RUnlock is called on all paths (error and success)
-				defer l.mu.RUnlock()
-
-				klog.V(3).Infof("Received postgres event, forwarding to %d subscriptions.",
-					len(l.subscriptions))
-
-				var notificationPayload model.Event
-				err := json.Unmarshal([]byte(notification.Payload), &notificationPayload)
-				if err != nil {
-					klog.Errorf("Failed to unmarshal notification payload: %v", err)
-					continue
-				}
-
-				// If the notification payload was too large, data was truncated.
-				// We need to query the database to rebuild the data.
-				if notificationPayload.NewData == nil &&
-					(notificationPayload.Operation == "INSERT" || notificationPayload.Operation == "UPDATE") {
-					klog.V(2).Infof("Notification payload missing newData, querying the database. UID: %s", notificationPayload.UID)
-					rows, err := l.conn.Query(l.ctx, fmt.Sprintf("SELECT data FROM search.resources WHERE uid = '%s'", notificationPayload.UID))
-					if err != nil {
-						klog.Errorf("Failed to execute query: %v", err)
-						continue
-					}
-
-					// Explicitly close rows after processing to avoid resource leak
-					for rows.Next() {
-						var data map[string]any
-						err := rows.Scan(&data)
-						if err != nil {
-							klog.Errorf("Failed to scan result: %v", err)
-							continue
-						}
-						notificationPayload.NewData = data
-					}
-					rows.Close()
-
-					// Check for errors from iteration
-					if err := rows.Err(); err != nil {
-						klog.Errorf("Error iterating rows: %v", err)
-					}
-				}
-				if notificationPayload.OldData == nil &&
-					(notificationPayload.Operation == "UPDATE" || notificationPayload.Operation == "DELETE") {
-					klog.Warningf("Notification payload was truncated, 'oldData' is missing. This is a current limitation. UID: %s", notificationPayload.UID)
-				}
-
-				for _, sub := range l.subscriptions {
-					select {
-					case <-sub.Context.Done():
-						klog.V(3).Infof("Subscription %s context is done, skipping", sub.ID)
-						continue
-					default:
-						sub.Channel <- &notificationPayload
-					}
-				}
+				l.forwardNotification(notification)
 			}
+		}
+	}
+}
+
+// forwardNotification parses a Postgres notification and sends it to all registered subscriptions.
+// The DB backfill query runs without holding l.mu to avoid blocking RegisterSubscription/UnregisterSubscription
+// during slow queries. The RLock is acquired only for the channel fan-out; sends are non-blocking
+// (events are dropped if a channel is full) so the lock is never held indefinitely. Holding the
+// RLock during sends is required for safety: it prevents UnregisterSubscription (which needs the
+// write lock) from completing while a send is in progress, ensuring subscriber channels are not
+// closed mid-send.
+func (l *Listener) forwardNotification(notification *pgconn.Notification) {
+	var notificationPayload model.Event
+	err := json.Unmarshal([]byte(notification.Payload), &notificationPayload)
+	if err != nil {
+		klog.Errorf("Failed to unmarshal notification payload: %v", err)
+		return
+	}
+
+	// If the notification payload was too large, data was truncated.
+	// We need to query the database to rebuild the data.
+	// This DB call happens without holding l.mu to avoid blocking subscription registration.
+	if notificationPayload.NewData == nil &&
+		(notificationPayload.Operation == "INSERT" || notificationPayload.Operation == "UPDATE") {
+		klog.V(2).Infof("Notification payload missing newData, querying the database. UID: %s", notificationPayload.UID)
+		rows, err := l.conn.Query(l.ctx, "SELECT data FROM search.resources WHERE uid = $1", notificationPayload.UID)
+		if err != nil {
+			klog.Errorf("Failed to execute query: %v", err)
+			return
+		}
+
+		// Explicitly close rows after processing to avoid resource leak
+		for rows.Next() {
+			var data map[string]any
+			err := rows.Scan(&data)
+			if err != nil {
+				klog.Errorf("Failed to scan result: %v", err)
+				continue
+			}
+			notificationPayload.NewData = data
+		}
+		rows.Close()
+
+		// Check for errors from iteration
+		if err := rows.Err(); err != nil {
+			klog.Errorf("Error iterating rows: %v", err)
+		}
+	}
+	if notificationPayload.OldData == nil &&
+		(notificationPayload.Operation == "UPDATE" || notificationPayload.Operation == "DELETE") {
+		klog.Warningf("Notification payload was truncated, 'oldData' is missing. This is a current limitation. UID: %s", notificationPayload.UID)
+	}
+
+	// Hold RLock during fan-out. Non-blocking sends ensure we never block while holding the lock.
+	// The RLock also prevents subscriber channels from being closed mid-send (UnregisterSubscription
+	// needs the write lock and must wait for all readers to finish).
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	klog.V(3).Infof("Received postgres event, forwarding to %d subscriptions.", len(l.subscriptions))
+	for _, sub := range l.subscriptions {
+		select {
+		case <-sub.Context.Done():
+			klog.V(3).Infof("Subscription %s context is done, skipping", sub.ID)
+		case sub.Channel <- &notificationPayload:
+		default:
+			klog.Warningf("Subscription %s channel buffer is full, dropping event.", sub.ID)
 		}
 	}
 }

--- a/pkg/database/listener.go
+++ b/pkg/database/listener.go
@@ -301,22 +301,26 @@ func (l *Listener) forwardNotification(notification *pgconn.Notification) {
 			klog.Errorf("Failed to execute query: %v", err)
 			return
 		}
+		defer rows.Close()
 
-		// Explicitly close rows after processing to avoid resource leak
-		for rows.Next() {
+		found := false
+		if rows.Next() {
 			var data map[string]any
-			err := rows.Scan(&data)
-			if err != nil {
+			if err := rows.Scan(&data); err != nil {
 				klog.Errorf("Failed to scan result: %v", err)
-				continue
+				return
 			}
 			notificationPayload.NewData = data
+			found = true
 		}
-		rows.Close()
 
-		// Check for errors from iteration
 		if err := rows.Err(); err != nil {
 			klog.Errorf("Error iterating rows: %v", err)
+			return
+		}
+		if !found {
+			klog.Errorf("Backfill query returned no rows for UID: %s", notificationPayload.UID)
+			return
 		}
 	}
 	if notificationPayload.OldData == nil &&

--- a/pkg/database/listener_test.go
+++ b/pkg/database/listener_test.go
@@ -1208,3 +1208,213 @@ func TestCheckAndCloseExpiredSubscriptions_IdleTimeout(t *testing.T) {
 		// Channel is full (buffered), which is also fine — it was not closed.
 	}
 }
+
+// buildTestListener creates a minimal Listener with a mock connection and one subscription.
+func buildTestListener(ctx context.Context, subID string, ch chan *model.Event, conn MockPgxConnIface) (*Listener, *Subscription) {
+	subCtx, subCancel := context.WithCancel(ctx)
+	sub := &Subscription{
+		ID:      subID,
+		Channel: ch,
+		Context: subCtx,
+		Cancel:  subCancel,
+	}
+	l := &Listener{
+		ctx:           ctx,
+		subscriptions: map[string]*Subscription{subID: sub},
+		conn:          conn,
+	}
+	return l, sub
+}
+
+// TestForwardNotification_InvalidJSON verifies that a malformed payload is dropped gracefully.
+func TestForwardNotification_InvalidJSON(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *model.Event, 10)
+	l, _ := buildTestListener(ctx, "sub-1", ch, MockPgxConn{})
+
+	l.forwardNotification(&pgconn.Notification{Payload: `not-valid-json`})
+
+	assert.Equal(t, 0, len(ch), "No event should be forwarded on JSON parse failure")
+}
+
+// TestForwardNotification_DBQueryError verifies that a DB error during backfill drops the event.
+func TestForwardNotification_DBQueryError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	queryCalled := false
+	conn := MockPgxConn{
+		QueryFunc: func(ctx context.Context, sql string, arguments ...interface{}) (pgx.Rows, error) {
+			queryCalled = true
+			return nil, assert.AnError
+		},
+	}
+	ch := make(chan *model.Event, 10)
+	l, _ := buildTestListener(ctx, "sub-1", ch, conn)
+
+	// INSERT with no newData triggers the DB backfill path.
+	l.forwardNotification(&pgconn.Notification{
+		Payload: `{"uid":"u1","operation":"INSERT","timestamp":"2024-01-01T00:00:00Z"}`,
+	})
+
+	assert.True(t, queryCalled, "DB query should have been attempted")
+	assert.Equal(t, 0, len(ch), "No event should be forwarded when DB query fails")
+}
+
+// TestForwardNotification_ChannelFull verifies that a full channel drops the event without blocking.
+func TestForwardNotification_ChannelFull(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *model.Event, 2)
+	// Pre-fill the channel to capacity.
+	ch <- &model.Event{}
+	ch <- &model.Event{}
+
+	l, _ := buildTestListener(ctx, "sub-1", ch, MockPgxConn{})
+
+	done := make(chan struct{})
+	go func() {
+		l.forwardNotification(&pgconn.Notification{
+			Payload: `{"uid":"u1","operation":"CREATE","timestamp":"2024-01-01T00:00:00Z"}`,
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good: returned promptly without blocking.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("forwardNotification blocked on a full channel")
+	}
+	assert.Equal(t, 2, len(ch), "Channel length should be unchanged (new event dropped)")
+}
+
+// TestForwardNotification_CancelledSubscription verifies that a cancelled subscription is skipped.
+func TestForwardNotification_CancelledSubscription(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan *model.Event, 10)
+	l, sub := buildTestListener(ctx, "sub-1", ch, MockPgxConn{})
+
+	sub.Cancel() // cancel before forwarding
+
+	l.forwardNotification(&pgconn.Notification{
+		Payload: `{"uid":"u1","operation":"CREATE","timestamp":"2024-01-01T00:00:00Z"}`,
+	})
+
+	assert.Equal(t, 0, len(ch), "Cancelled subscription should not receive events")
+}
+
+// TestForwardNotification_MultipleSubscriptions verifies the event is sent to all active subscribers.
+func TestForwardNotification_MultipleSubscriptions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch1 := make(chan *model.Event, 10)
+	ch2 := make(chan *model.Event, 10)
+	subCtx1, subCancel1 := context.WithCancel(ctx)
+	subCtx2, subCancel2 := context.WithCancel(ctx)
+	defer subCancel1()
+	defer subCancel2()
+
+	l := &Listener{
+		ctx: ctx,
+		subscriptions: map[string]*Subscription{
+			"sub-1": {ID: "sub-1", Channel: ch1, Context: subCtx1, Cancel: subCancel1},
+			"sub-2": {ID: "sub-2", Channel: ch2, Context: subCtx2, Cancel: subCancel2},
+		},
+		conn: MockPgxConn{},
+	}
+
+	l.forwardNotification(&pgconn.Notification{
+		Payload: `{"uid":"u1","operation":"CREATE","timestamp":"2024-01-01T00:00:00Z"}`,
+	})
+
+	assert.Equal(t, 1, len(ch1), "sub-1 should receive the event")
+	assert.Equal(t, 1, len(ch2), "sub-2 should receive the event")
+}
+
+// TestForwardNotification_MixedSubscriptions verifies active subscribers receive the event
+// while cancelled ones are skipped.
+func TestForwardNotification_MixedSubscriptions(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	chActive := make(chan *model.Event, 10)
+	chCancelled := make(chan *model.Event, 10)
+	activeCtx, activeCancel := context.WithCancel(ctx)
+	cancelledCtx, cancelledCancel := context.WithCancel(ctx)
+	defer activeCancel()
+	cancelledCancel() // cancel immediately
+
+	l := &Listener{
+		ctx: ctx,
+		subscriptions: map[string]*Subscription{
+			"active":    {ID: "active", Channel: chActive, Context: activeCtx, Cancel: activeCancel},
+			"cancelled": {ID: "cancelled", Channel: chCancelled, Context: cancelledCtx, Cancel: cancelledCancel},
+		},
+		conn: MockPgxConn{},
+	}
+
+	l.forwardNotification(&pgconn.Notification{
+		Payload: `{"uid":"u1","operation":"CREATE","timestamp":"2024-01-01T00:00:00Z"}`,
+	})
+
+	assert.Equal(t, 1, len(chActive), "Active subscription should receive the event")
+	assert.Equal(t, 0, len(chCancelled), "Cancelled subscription should not receive the event")
+}
+
+// TestForwardNotification_DeleteDoesNotTriggerBackfill verifies DELETE events skip DB backfill.
+func TestForwardNotification_DeleteDoesNotTriggerBackfill(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	queryCalled := false
+	conn := MockPgxConn{
+		QueryFunc: func(ctx context.Context, sql string, arguments ...interface{}) (pgx.Rows, error) {
+			queryCalled = true
+			return nil, nil
+		},
+	}
+	ch := make(chan *model.Event, 10)
+	l, _ := buildTestListener(ctx, "sub-1", ch, conn)
+
+	// DELETE with no oldData — should log a warning but not query DB.
+	l.forwardNotification(&pgconn.Notification{
+		Payload: `{"uid":"u1","operation":"DELETE","timestamp":"2024-01-01T00:00:00Z"}`,
+	})
+
+	assert.False(t, queryCalled, "DB should not be queried for DELETE events")
+	assert.Equal(t, 1, len(ch), "DELETE event should still be forwarded to subscribers")
+}
+
+// TestForwardNotification_InsertWithFullPayload verifies that an INSERT with newData present
+// skips the DB backfill and is forwarded directly.
+func TestForwardNotification_InsertWithFullPayload(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	queryCalled := false
+	conn := MockPgxConn{
+		QueryFunc: func(ctx context.Context, sql string, arguments ...interface{}) (pgx.Rows, error) {
+			queryCalled = true
+			return nil, nil
+		},
+	}
+	ch := make(chan *model.Event, 10)
+	l, _ := buildTestListener(ctx, "sub-1", ch, conn)
+
+	l.forwardNotification(&pgconn.Notification{
+		Payload: `{"uid":"u1","operation":"INSERT","timestamp":"2024-01-01T00:00:00Z","newData":{"kind":"ConfigMap","name":"my-cm"}}`,
+	})
+
+	assert.False(t, queryCalled, "DB should not be queried when newData is present")
+	assert.Equal(t, 1, len(ch), "Event should be forwarded to subscriber")
+	event := <-ch
+	assert.Equal(t, "u1", event.UID)
+	assert.Equal(t, "ConfigMap", event.NewData["kind"])
+}

--- a/pkg/database/listener_test.go
+++ b/pkg/database/listener_test.go
@@ -1118,7 +1118,7 @@ func TestCheckAndCloseExpiredSubscriptions_MaxLifetime(t *testing.T) {
 		config.Cfg.Subscription.IdleTimeout = originalIdleTimeout
 	}()
 
-	config.Cfg.Subscription.MaxLifetime = 10      // 10 ms (will trigger)
+	config.Cfg.Subscription.MaxLifetime = 10        // 10 ms (will trigger)
 	config.Cfg.Subscription.IdleTimeout = 10 * 1000 // 10 seconds (won't trigger)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/database/listener_test.go
+++ b/pkg/database/listener_test.go
@@ -917,6 +917,18 @@ func (m *MockRows) Scan(dest ...interface{}) error {
 func (m *MockRows) Values() ([]interface{}, error) { return nil, nil }
 func (m *MockRows) RawValues() [][]byte            { return nil }
 
+// ErrorScanRows is a mock pgx.Rows that returns one row but fails on Scan.
+type ErrorScanRows struct{ called bool }
+
+func (r *ErrorScanRows) Close()                                         {}
+func (r *ErrorScanRows) Err() error                                     { return nil }
+func (r *ErrorScanRows) CommandTag() pgconn.CommandTag                  { return nil }
+func (r *ErrorScanRows) FieldDescriptions() []pgproto3.FieldDescription { return nil }
+func (r *ErrorScanRows) Next() bool                                     { v := !r.called; r.called = true; return v }
+func (r *ErrorScanRows) Scan(dest ...interface{}) error                 { return assert.AnError }
+func (r *ErrorScanRows) Values() ([]interface{}, error)                 { return nil, nil }
+func (r *ErrorScanRows) RawValues() [][]byte                            { return nil }
+
 // [AI] Test listen() with large payload where data is truncated
 func TestListen_WithLargePayload(t *testing.T) {
 	listenCtx, listenCancel := context.WithCancel(context.Background())
@@ -1417,4 +1429,52 @@ func TestForwardNotification_InsertWithFullPayload(t *testing.T) {
 	event := <-ch
 	assert.Equal(t, "u1", event.UID)
 	assert.Equal(t, "ConfigMap", event.NewData["kind"])
+}
+
+// TestForwardNotification_BackfillNoRows verifies that an INSERT/UPDATE with no matching DB row is dropped.
+func TestForwardNotification_BackfillNoRows(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn := MockPgxConn{
+		QueryFunc: func(ctx context.Context, sql string, arguments ...interface{}) (pgx.Rows, error) {
+			// Return empty rows (no results found).
+			return &MockRows{nextCalled: 1}, nil // nextCalled=1 so Next() returns false immediately
+		},
+	}
+	ch := make(chan *model.Event, 10)
+	l, _ := buildTestListener(ctx, "sub-1", ch, conn)
+
+	l.forwardNotification(&pgconn.Notification{
+		Payload: `{"uid":"missing-uid","operation":"INSERT","timestamp":"2024-01-01T00:00:00Z"}`,
+	})
+
+	assert.Equal(t, 0, len(ch), "Event with no backfill data should be dropped")
+}
+
+// TestForwardNotification_BackfillScanError verifies that a scan error during backfill drops the event.
+func TestForwardNotification_BackfillScanError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn := MockPgxConn{
+		QueryFunc: func(ctx context.Context, sql string, arguments ...interface{}) (pgx.Rows, error) {
+			return &MockRows{data: nil}, nil // Scan into *map[string]any with nil triggers no error, but data is nil
+		},
+	}
+	_ = conn
+	// Use a rows mock that returns an error from Scan.
+	ch := make(chan *model.Event, 10)
+	scanErrConn := MockPgxConn{
+		QueryFunc: func(ctx context.Context, sql string, arguments ...interface{}) (pgx.Rows, error) {
+			return &ErrorScanRows{}, nil
+		},
+	}
+	l, _ := buildTestListener(ctx, "sub-1", ch, scanErrConn)
+
+	l.forwardNotification(&pgconn.Notification{
+		Payload: `{"uid":"u1","operation":"INSERT","timestamp":"2024-01-01T00:00:00Z"}`,
+	})
+
+	assert.Equal(t, 0, len(ch), "Event should be dropped when scan fails")
 }

--- a/pkg/database/listener_test.go
+++ b/pkg/database/listener_test.go
@@ -941,7 +941,8 @@ func TestListen_WithLargePayload(t *testing.T) {
 			return notification, nil
 		},
 		QueryFunc: func(ctx context.Context, sql string, arguments ...interface{}) (pgx.Rows, error) {
-			assert.Contains(t, sql, "SELECT data FROM search.resources WHERE uid = 'test-uid-large'")
+			assert.Contains(t, sql, "SELECT data FROM search.resources WHERE uid = $1")
+			assert.Equal(t, "test-uid-large", arguments[0])
 			return &MockRows{
 				data:    expectedData,
 				cluster: expectedCluster,

--- a/pkg/resolver/watchSubscription.go
+++ b/pkg/resolver/watchSubscription.go
@@ -434,7 +434,7 @@ func WatchSubscription(ctx context.Context, input *model.SearchInput) (<-chan *m
 					return
 				default:
 					klog.Warningf("Subscription watch(%s) channel buffer is full, dropping event.", subID)
-					return
+					continue
 				}
 			}
 		}


### PR DESCRIPTION
### Related Issue
- E2E tests failing.
- Problems with multiple subscriptions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscriptions are more resilient: if delivering an event to a client would block, the event is skipped and processing continues instead of terminating the subscription.
  * Skips cancelled subscribers without impacting others.

* **Refactor**
  * Notification handling and delivery were reorganized for non-blocking dispatch, safer backfill handling, and improved stability and observability.
  * Backfill queries now use parameterized execution.

* **Tests**
  * Added tests for notification parsing, backfill outcomes, channel-full behavior, and multi-subscriber scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->