### PR TITLE
chore: onboard repository to Fleet Engineering Agentic SDLC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# search-v2-api
+
+ACM Search API. Reads from the shared PostgreSQL database written by search-indexer RBAC and serves queries with a GraphQL endpoint.
+
+For system architecture, data flows, and module layout, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+## Commands
+
+```bash
+make setup          # Generate TLS cert + print DB env var instructions (run once before first local run)
+make run            # Run locally (enables playground and dev feature flags automatically)
+make test           # Unit tests
+make test-race      # Unit tests with race detector
+make coverage       # Unit tests with HTML coverage report (runs test first)
+make docker-build   # Build Docker image
+make lint           # Run golangci-lint + gosec (downloads golangci-lint if not present)
+make gqlgen         # Regenerate GraphQL code from schema (run after editing graph/schema.graphqls)
+make send QUERY=schema          # Send a test GraphQL request (values: schema, search, searchComplete, searchCount, searchRelated, vm)
+```
+
+## Required environment variables
+
+The service exits on startup if these are missing:
+
+| Variable | Description |
+|---|---|
+| `DB_NAME` | PostgreSQL database name |
+| `DB_USER` | PostgreSQL user |
+| `DB_PASS` | PostgreSQL password |
+
+`make setup` prints the `oc` commands to extract these from a live cluster and the port-forward command to reach it locally.
+
+Optional overrides (defaults): `DB_HOST=localhost`, `DB_PORT=5432`, `HTTP_PORT=4010`, `CONTEXT_PATH=/searchapi`.
+
+## Non-obvious conventions
+
+- **`-tags development` build tag** enables development mode: sets `DevelopmentMode=true` and enables `FEATURE_FEDERATED_SEARCH`, `FEATURE_FINE_GRAINED_RBAC`, and `FEATURE_SUBSCRIPTION` by default. `make run` uses this tag automatically.
+- **`PLAYGROUND_MODE=true`** is set by `make run` — opens the GraphQL playground at `https://localhost:4010/playground`. Not enabled in production.
+- **`graph/generated/` is generated code** — never edit manually. Run `make gqlgen` after any change to `graph/schema.graphqls`.
+- **TLS cert required** even locally. `make setup` generates a self-signed cert at `sslcert/tls.crt` + `sslcert/tls.key`.
+- **Port 4010** (not 3010, which is search-indexer).
+- **Federated search** is off by default (`FEATURE_FEDERATED_SEARCH=false`). It requires a `ManagedHubConfig` in the cluster and routes requests to remote hub search APIs. Enabled automatically in dev mode.
+- **`make coverage` depends on `make test`** — it reads `cover.out` produced by the test target rather than re-running tests.
+- **`make lint` excludes `graph/generated/`** via `-exclude-dir=graph/generated` in the gosec invocation.
+
+## Fleet Engineering Skills
+
+All skills are available as slash commands. See the [Fleet Engineering skills catalog](https://github.com/OpenShift-Fleet/agentic-sdlc/blob/main/skills/README.md) for the full list with when-to-use guidance.
+
+## Personal configuration
+
+Read personal config at the start of any task that needs an assignee, email, or project key.
+Use the tool-aware fallback chain: `~/.config/opencode/user.local.md` (OpenCode),
+`.claude/user.local.md` (Claude Code), or `.cursor/rules/user.local.mdc` (Cursor, already in context).
+If none exist, fall back to agent memory (`user-config`), then placeholders.
+Run `make personalize` to generate all three files (if this repo uses Fleet Engineering tooling).
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,95 @@
+# search-v2-api Architecture
+
+## Overview
+
+search-v2-api is the read path for ACM Search. It is an HTTPS GraphQL service running in the hub cluster. It reads from the same PostgreSQL database that `search-indexer` writes to and enforces RBAC on every response. Clients (the ACM console and the federated hub) talk exclusively to this service.
+
+```text
+ACM Console / CLI
+        │  HTTPS POST /searchapi/graphql
+        ▼
+  search-v2-api ──────────────────────────────► PostgreSQL (read)
+        │                                        search.resources
+        │  (optional, FEATURE_FEDERATED_SEARCH)  search.edges
+        └──────────────► Remote Hub search-v2-api instances
+```
+
+## Packages
+
+| Package | Responsibility |
+|---|---|
+| `main` | Bootstrap: init config, connect DB, start RBAC background validation, start server, wait for SIGINT/SIGTERM |
+| `pkg/config` | All configuration from environment variables. `Cfg` is a package-level singleton. Development mode is a build tag (`-tags development`), not an env var. |
+| `pkg/server` | HTTPS server on `:4010`. Routes: `/liveness`, `/readiness`, `/metrics`, `/searchapi/graphql` (authenticated), `/federated` (optional), `/playground` (dev only). Applies middleware: timeout, Prometheus, DB availability check, authn, authz. Configures gqlgen handler with GET/POST/WebSocket transports. |
+| `pkg/rbac` | RBAC enforcement. TokenReview cache (`AuthCacheTTL`), shared resource cache (`SharedCacheTTL`), per-user namespace permission cache (`UserCacheTTL`). Background goroutine invalidates stale cache entries. |
+| `pkg/resolver` | GraphQL resolver implementations: `search`, `searchComplete`, `searchSchema`, `messages`, `watch` (subscription). Translates GraphQL input to SQL via goqu and applies RBAC filtering to results. |
+| `pkg/federated` | Federated search: reads `ManagedHubConfig` from the cluster, maintains an HTTP client pool, fans out queries to remote hub APIs, and merges responses. |
+| `pkg/database` | PostgreSQL connection pool (`pgxpool`). Also manages the `LISTEN/NOTIFY` listener used by GraphQL subscriptions. |
+| `pkg/metrics` | Prometheus registry and `PrometheusMiddleware`. |
+| `graph/` | gqlgen schema (`schema.graphqls`), generated code (`generated/`), and resolver wiring (`resolver.go`, `schema.resolvers.go`). Never edit `generated/` by hand — run `make gqlgen` after schema changes. |
+
+## GraphQL API surface
+
+| Operation | Type | Description |
+|---|---|---|
+| `search(input)` | Query | Search for resources and their relationships. Returns `items`, `count`, `related`. |
+| `searchComplete(property, query, limit)` | Query | All distinct values for a property, optionally filtered. |
+| `searchSchema(query)` | Query | All indexed property names, optionally filtered. |
+| `messages` | Query | Service-level status messages (e.g. DB unavailable). |
+| `watch(input)` | Subscription | Real-time stream of INSERT/UPDATE/DELETE events matching the filter. Delivered over WebSocket. |
+
+Filters support operators (`=`, `!`, `!=`, `>`, `>=`, `<`, `<=`), wildcard (`*`), and datetime shortcuts (`hour`, `day`, `week`, `month`, `year`). Multiple values within a filter are OR'd; multiple filters are AND'd.
+
+## Key data flows
+
+### Standard query (`search`, `searchComplete`, `searchSchema`)
+
+1. Request hits `/searchapi/graphql` and passes through middleware in order: timeout → Prometheus → DB availability → authn (TokenReview) → authz (RBAC namespace lookup).
+2. `pkg/rbac.AuthorizeUser` populates the request context with the user's allowed namespaces and cluster-scoped resources.
+3. Resolver (`pkg/resolver/search.go`) builds a SQL query against `search.resources` / `search.edges` using goqu, inlining the RBAC namespace allowlist as a `WHERE` clause.
+4. Results are returned directly — no further post-filtering.
+
+### GraphQL subscription (`watch`)
+
+1. Client opens a WebSocket to `/searchapi/graphql`.
+2. On subscribe, the resolver registers a listener channel with `pkg/database`'s PostgreSQL `LISTEN/NOTIFY` listener.
+3. The DB listener receives `NOTIFY` events from `listenerTrigger.sql` (a trigger on `search.resources`) and broadcasts change payloads.
+4. Each event is RBAC-filtered before being sent to the client.
+5. Subscriptions are bounded by `SUBSCRIPTION_MAX_ACTIVE`, `SUBSCRIPTION_MAX_LIFETIME`, and `SUBSCRIPTION_IDLE_TIMEOUT`.
+
+### Federated search (`/federated`)
+
+1. Only active when `FEATURE_FEDERATED_SEARCH=true`.
+2. `federated.HandleFederatedRequest` reads the `ManagedHubConfig` ConfigMap (cached, `FEDERATION_CONFIG_CACHE_TTL`) to discover remote hub API endpoints.
+3. The incoming GraphQL request is proxied concurrently to all registered remote hubs via an HTTP client pool.
+4. Responses are merged and returned as a unified result (`pkg/federated/mergeResponses.go`).
+
+## RBAC cache layers
+
+Three independently-TTL'd caches protect the Kubernetes API server:
+
+| Cache | Default TTL | What it stores |
+|---|---|---|
+| Auth (TokenReview) | 1 min (`AUTH_CACHE_TTL`) | Whether a bearer token is valid and which user it belongs to |
+| Shared | 5 min (`SHARED_CACHE_TTL`) | Cluster-scoped resources visible to all users |
+| User | 5 min (`USER_CACHE_TTL`) | Per-user namespace list and resource permissions |
+
+A background goroutine (`StartBackgroundValidation`) periodically re-validates entries and evicts stale ones.
+
+## Feature flags
+
+| Env variable | Default | Effect |
+|---|---|---|
+| `FEATURE_FEDERATED_SEARCH` | `false` (dev: `true`) | Enables `/federated` endpoint and federated query fan-out |
+| `FEATURE_FINE_GRAINED_RBAC` | `false` (dev: `true`) | Enables per-resource-type RBAC filtering beyond namespace-level |
+| `FEATURE_SUBSCRIPTION` | `true` | Enables the `watch` GraphQL subscription over WebSocket |
+| `PLAYGROUND_MODE` | `false` (set by `make run`) | Exposes `/playground` GraphQL UI |
+| `API_DOCUMENTATION` | `false` | Enables GraphQL introspection (schema documentation endpoint) |
+
+## Design decisions
+
+- **gqlgen code generation**: The GraphQL schema (`graph/schema.graphqls`) is the source of truth. `make gqlgen` regenerates `graph/generated/` and stubs in `graph/schema.resolvers.go`. Resolver logic lives in `pkg/resolver/`, separate from the generated wiring.
+- **RBAC inlined into SQL**: Rather than fetching all results and filtering in Go, the allowed namespace list is passed directly into the SQL `WHERE` clause. This avoids loading data the user cannot see.
+- **PostgreSQL LISTEN/NOTIFY for subscriptions**: Avoids polling. A SQL trigger fires `NOTIFY` on every insert/update/delete in `search.resources`; the Go listener receives these and fans out to WebSocket subscribers.
+- **Federated response merging**: Remote hub responses are merged in memory. Deduplication is by resource UID.
+- **No ORM**: Raw SQL via `pgx`/`goqu`, consistent with search-indexer.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with verified `make`-based commands, required env vars, and non-obvious conventions (dev build tag, `make gqlgen` requirement, port 4010, feature flags, playground mode)
- Add `docs/ARCHITECTURE.md` covering service overview, package responsibilities, GraphQL API surface, key data flows (standard query, subscription via PostgreSQL LISTEN/NOTIFY, federated search), RBAC cache layers, and design decisions

## Test plan

- [x] Verify `make` commands in `CLAUDE.md` match the `Makefile` targets
- [x] Review `docs/ARCHITECTURE.md` for accuracy against the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added service setup and development documentation with configuration and environment variable guidance.
  * Added architectural documentation outlining API surface, data flow, cache mechanisms, and design decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->