### PR TITLE
ACM-30184 - tls profile consistency

### DIFF
--- a/pkg/config/tlsconfig.go
+++ b/pkg/config/tlsconfig.go
@@ -1,0 +1,86 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package config
+
+import (
+	"crypto/tls"
+	"os"
+	"strconv"
+	"strings"
+
+	klog "k8s.io/klog/v2"
+)
+
+// GetTLSConfig builds a *tls.Config from environment variables set by the operator.
+//
+// Expected env vars (set by the search-v2-operator from the cluster's APIServer TLS profile):
+//   - TLS_MIN_VERSION: uint16 value as string (e.g. "771" for TLS 1.2, "772" for TLS 1.3)
+//   - TLS_CIPHERS: comma-separated IANA cipher suite names
+//     (e.g. "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+//
+// If the env vars are not set (development mode, non-operator deployment), defaults to
+// TLS 1.2 with Go's default cipher suite selection.
+func GetTLSConfig() *tls.Config {
+	minVersion := defaultMinVersion
+	cipherSuites := []uint16(nil)
+
+	if v := os.Getenv("TLS_MIN_VERSION"); v != "" {
+		parsed, err := strconv.ParseUint(v, 10, 16)
+		if err != nil {
+			klog.Warningf("Invalid TLS_MIN_VERSION %q, using default TLS 1.2: %v", v, err)
+		} else {
+			minVersion = uint16(parsed)
+			// e.g. (770&0xff) - 1 = 2 - 1 = 1 -> TLS 1.1, (769&0xff) - 1 = 1 - 1 = 0 -> TLS 1.0
+			klog.Infof("TLS min version from env: TLS 1.%d", (minVersion&0xff)-1)
+		}
+	}
+
+	if v := os.Getenv("TLS_CIPHERS"); v != "" {
+		names := strings.Split(v, ",")
+		cipherSuites = cipherSuitesFromNames(names)
+		if len(cipherSuites) == 0 {
+			klog.Warning("No valid cipher suites resolved from TLS_CIPHERS, using Go defaults")
+		} else {
+			klog.Infof("TLS cipher suites from env: %d configured", len(cipherSuites))
+		}
+	}
+
+	return &tls.Config{
+		MinVersion:   minVersion,
+		CipherSuites: cipherSuites,
+	}
+}
+
+const defaultMinVersion uint16 = tls.VersionTLS12
+
+// cipherSuitesFromNames resolves IANA cipher suite names to crypto/tls uint16 IDs
+// using Go's stdlib. No hardcoded map — automatically picks up new ciphers when Go adds them.
+func cipherSuitesFromNames(names []string) []uint16 {
+	lookup := map[string]uint16{}
+	for _, cs := range tls.CipherSuites() {
+		lookup[cs.Name] = cs.ID
+	}
+	for _, cs := range tls.InsecureCipherSuites() {
+		lookup[cs.Name] = cs.ID
+	}
+
+	var result []uint16
+	var unknown []string
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if id, ok := lookup[name]; ok {
+			result = append(result, id)
+		} else {
+			unknown = append(unknown, name)
+		}
+	}
+
+	if len(unknown) > 0 {
+		klog.Warningf("TLS cipher suites not recognized by Go, skipped: %v", unknown)
+	}
+
+	return result
+}

--- a/pkg/config/tlsconfig_test.go
+++ b/pkg/config/tlsconfig_test.go
@@ -1,0 +1,97 @@
+// Copyright Contributors to the Open Cluster Management project
+
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCipherSuitesFromNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []string
+		want  []uint16
+	}{
+		{
+			name:  "valid ECDHE ciphers",
+			input: []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+			want:  []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+		},
+		{
+			name:  "unknown ciphers skipped",
+			input: []string{"UNKNOWN_CIPHER", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+			want:  []uint16{tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+		},
+		{
+			name:  "all unknown returns nil",
+			input: []string{"UNKNOWN_1", "UNKNOWN_2"},
+			want:  nil,
+		},
+		{
+			name:  "empty input",
+			input: []string{},
+			want:  nil,
+		},
+		{
+			name:  "whitespace trimmed",
+			input: []string{" TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+			want:  []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384},
+		},
+		{
+			name:  "empty strings filtered",
+			input: []string{"", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", ""},
+			want:  []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cipherSuitesFromNames(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetTLSConfig_Defaults(t *testing.T) {
+	t.Setenv("TLS_MIN_VERSION", "")
+	t.Setenv("TLS_CIPHERS", "")
+
+	cfg := GetTLSConfig()
+
+	assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+	assert.Nil(t, cfg.CipherSuites, "No env var should leave CipherSuites nil (Go defaults)")
+}
+
+func TestGetTLSConfig_WithEnvVars(t *testing.T) {
+	t.Setenv("TLS_MIN_VERSION", "772") // TLS 1.3
+	t.Setenv("TLS_CIPHERS", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+
+	cfg := GetTLSConfig()
+
+	assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+	assert.Equal(t, []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	}, cfg.CipherSuites)
+}
+
+func TestGetTLSConfig_InvalidMinVersion(t *testing.T) {
+	t.Setenv("TLS_MIN_VERSION", "not-a-number")
+	t.Setenv("TLS_CIPHERS", "")
+
+	cfg := GetTLSConfig()
+
+	assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion, "Should fall back to TLS 1.2")
+}
+
+func TestGetTLSConfig_InvalidCiphers(t *testing.T) {
+	t.Setenv("TLS_MIN_VERSION", "")
+	t.Setenv("TLS_CIPHERS", "TOTALLY_FAKE_CIPHER")
+
+	cfg := GetTLSConfig()
+
+	assert.Empty(t, cfg.CipherSuites, "Unresolvable ciphers should result in empty list")
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,15 +26,8 @@ import (
 func StartAndListen(ctx context.Context) {
 	port := config.Cfg.HttpPort
 
-	// Configure TLS
-	cfg := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
-		PreferServerCipherSuites: true,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		},
-	}
+	// Get TLS configuration from operator-provided env vars (or defaults).
+	cfg := config.GetTLSConfig()
 
 	// Initiate router
 	router := mux.NewRouter()


### PR DESCRIPTION
<!-- Include the Jira issue in the title, example: 'ACM-0000 Implement feature XYZ' -->

### Related Issue
<!-- Update Jira link -->
https://issues.redhat.com/browse/ACM-30184

### Description of changes
- Added tls config fetched from env vars set by operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based TLS configuration for minimum TLS version and cipher suites.
  * Defaults to TLS 1.2 when no valid minimum version is provided.
  * Supports recognized cipher suite names while ignoring invalid entries.
  * Applies the configured TLS settings when starting the server.

* **Bug Fixes**
  * Invalid TLS settings now fall back safely to secure defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->